### PR TITLE
Fix AirPlay 2 implementation: nonce reuse, metadata, event port, volume, sample rate

### DIFF
--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -713,6 +713,25 @@ class AudioCastService : Service() {
                 password = savedPin,
                 txtPk = parsePkFromExtra(dest.extra)
             )
+            ap2.eventListener = object : AirPlay2Client.EventListener {
+                override fun onVolumeChange(db: Double) {
+                    airPlay2VolumeDb[dest.host] = db.coerceIn(-30.0, 0.0)
+                }
+                override fun onRemoteCommand(command: String) {
+                    scope.launch {
+                        val mediaCmd = when (command.lowercase()) {
+                            "nextitem" -> MediaCommand.NEXT
+                            "previtem" -> MediaCommand.PREVIOUS
+                            "playpause" -> MediaCommand.TOGGLE
+                            "play" -> MediaCommand.PLAY
+                            "pause" -> MediaCommand.PAUSE
+                            "stop" -> MediaCommand.STOP
+                            else -> null
+                        }
+                        if (mediaCmd != null) _controlCommands.emit(mediaCmd)
+                    }
+                }
+            }
             if (!ap2.connect()) {
                 _state.value = CastState.ERROR
                 return

--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -103,6 +103,7 @@ class AudioCastService : Service() {
     private val controlSessions = mutableMapOf<String, DefaultClientWebSocketSession>()
     private val raopClients = mutableMapOf<String, RaopClient>()
     private val airPlay2Clients = mutableMapOf<String, AirPlay2Client>()
+    private val airPlay2VolumeDb = mutableMapOf<String, Double>()
     
     private val dacpId by lazy { 
         sharedPreferences.getString("dacp_id", null) ?: run {
@@ -332,8 +333,9 @@ class AudioCastService : Service() {
         val sessionScope = CoroutineScope(Dispatchers.IO + sessionJob!!)
 
         val hasAirPlay = destinations.any { it.platform == "AirPlay" }
-        val hasNonAirPlay = destinations.any { it.platform != "AirPlay" }
-        if (hasAirPlay && hasNonAirPlay) {
+        val hasAirPlay2 = destinations.any { it.platform == "AirPlay2" }
+        val hasNonAirPlay = destinations.any { it.platform != "AirPlay" && it.platform != "AirPlay2" }
+        if ((hasAirPlay || hasAirPlay2) && hasNonAirPlay) {
             Log.e(TAG, "AirPlay cannot be mixed with other targets")
             _state.value = CastState.ERROR
             return
@@ -345,7 +347,7 @@ class AudioCastService : Service() {
             return
         }
 
-        if (hasAirPlay) {
+        if (hasAirPlay || hasAirPlay2) {
             currentSampleRate = RAOP_SAMPLE_RATE
             currentFrameSizeBytes = RAOP_FRAME_BYTES
         } else {
@@ -716,6 +718,7 @@ class AudioCastService : Service() {
                 return
             }
             airPlay2Clients[dest.host] = ap2
+            airPlay2VolumeDb[dest.host] = 0.0
             _state.value = CastState.CASTING
             updateNotification()
 
@@ -897,10 +900,13 @@ class AudioCastService : Service() {
                             client.setVolumeDb(db)
                         } catch (e: Exception) {}
                     }
-                    airPlay2Clients.forEach { (_, client) ->
+                    airPlay2Clients.forEach { (host, client) ->
                         try {
-                            val db = if (direction == "up") -0.0 else -30.0
-                            client.setVolume(db)
+                            val current = airPlay2VolumeDb[host] ?: 0.0
+                            val next = if (direction == "up") (current + 3.0).coerceAtMost(0.0)
+                                       else (current - 3.0).coerceAtLeast(-30.0)
+                            airPlay2VolumeDb[host] = next
+                            client.setVolume(next)
                         } catch (e: Exception) {}
                     }
                 }
@@ -964,7 +970,15 @@ class AudioCastService : Service() {
                 } else if (dest.platform == "AirPlay") {
                     raopClients[dest.host]?.sendMetadata(finalMetadata.title, finalMetadata.artist, finalMetadata.album)
                 } else if (dest.platform == "AirPlay2") {
-                    // AirPlay 2 metadata TBD
+                    airPlay2Clients[dest.host]?.sendMetadata(
+                        finalMetadata.title, finalMetadata.artist, finalMetadata.album,
+                        currentArtworkBytes
+                    )
+                    val pos = finalMetadata.positionMs
+                    val dur = finalMetadata.durationMs
+                    if (pos != null && dur != null && dur > 0) {
+                        airPlay2Clients[dest.host]?.sendProgress(pos, dur)
+                    }
                 }
             } catch (e: Exception) {}
         }
@@ -1083,6 +1097,7 @@ class AudioCastService : Service() {
         raopClients.clear()
         airPlay2Clients.values.forEach { try { it.close() } catch (e: Exception) {} }
         airPlay2Clients.clear()
+        airPlay2VolumeDb.clear()
         _activeDestinations.value = emptyList()
         sessionJob?.cancel()
         sessionJob = null

--- a/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
+++ b/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
@@ -46,6 +46,8 @@ class AirPlay2Client(
     private val timingSocket = DatagramSocket(0)
     private val controlSocket = DatagramSocket(0)
     private var audioSocket: DatagramSocket? = null
+    private var eventSocket: Socket? = null
+    private var eventPort = 0
 
     private var timingRemotePort = 0
     private var controlRemotePort = 0
@@ -81,7 +83,8 @@ class AirPlay2Client(
             output = socket.getOutputStream()
             input = socket.getInputStream()
             localAddress = socket.localAddress.hostAddress ?: "0.0.0.0"
-            sessionUrl = "rtsp://$localAddress/$sessionUuid"
+            val urlHost = if (localAddress.contains(':')) "[$localAddress]" else localAddress
+            sessionUrl = "rtsp://$urlHost/$sessionUuid"
             sequence = secureRandom.nextInt(0xFFFF)
             rtpTimestamp = secureRandom.nextInt()
 
@@ -131,6 +134,7 @@ class AirPlay2Client(
 
             if (!sendSetupSession()) return false
             if (!sendRecord()) return false
+            connectEventPort()
             if (!sendSetupStream()) return false
 
             setVolume(0.0)
@@ -414,12 +418,15 @@ class AirPlay2Client(
 
     private fun parseSessionResponse(body: ByteArray) {
         try {
-            val xml = String(body, Charsets.UTF_8)
-            val eventPortRegex = Regex("<key>eventPort</key><integer>(\\d+)</integer>")
-            eventPortRegex.find(xml)?.let {
-                Log.d(TAG, "Event port: ${it.groupValues[1]}")
+            val dict = BinaryPlist.decode(body)
+            val port = (dict["eventPort"] as? Long)?.toInt()
+            if (port != null && port > 0) {
+                eventPort = port
+                Log.d(TAG, "Event port: $eventPort")
             }
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            Log.w(TAG, "parseSessionResponse failed: ${e.message}")
+        }
     }
 
     private fun parseTransportResponse(transport: String) {
@@ -446,14 +453,15 @@ class AirPlay2Client(
             val packet = buildRtpPacket(payload)
             val socket = audioSocket ?: return false
 
-            if (supportsEncryption && cipherKeys != null) {
+            val keys = cipherKeys
+            if (supportsEncryption && keys != null) {
+                val counter = synchronized(this) { keys.encryptionCounter++ }
                 val nonce = ByteArray(12)
-                nonce[4] = ((sequence shr 8) and 0xFF).toByte()
-                nonce[5] = (sequence and 0xFF).toByte()
+                for (i in 0..7) nonce[4 + i] = ((counter shr (i * 8)) and 0xFF).toByte()
                 val aad = packet.copyOfRange(4, 12)
                 val payloadEnc = packet.drop(12).toByteArray()
                 val (encrypted, tag) = AirPlay2Crypto.chacha20Poly1305Encrypt(
-                    cipherKeys!!.encryptionKey, nonce, payloadEnc, aad
+                    keys.encryptionKey, nonce, payloadEnc, aad
                 )
                 val finalPacket = packet.copyOfRange(0, 12) + encrypted + tag + nonce.copyOfRange(4, 12)
                 val dp = DatagramPacket(finalPacket, finalPacket.size, InetAddress.getByName(host), audioRemotePort)
@@ -519,12 +527,62 @@ class AirPlay2Client(
         sendRtspRequest("SET_PARAMETER", sessionUrl, "text/parameters", bodyBytes)
     }
 
+    fun sendMetadata(title: String?, artist: String?, album: String?, artworkBytes: ByteArray? = null) {
+        val dict = linkedMapOf<String, Any?>()
+        if (!title.isNullOrEmpty()) dict["dmap.itemname"] = title
+        if (!artist.isNullOrEmpty()) dict["daap.songartist"] = artist
+        if (!album.isNullOrEmpty()) dict["daap.songalbum"] = album
+        if (dict.isNotEmpty()) {
+            sendRtspRequest("SET_PARAMETER", sessionUrl,
+                "application/x-apple-binary-plist", BinaryPlist.encode(dict))
+        }
+        if (artworkBytes != null && artworkBytes.isNotEmpty()) {
+            sendRtspRequest("SET_PARAMETER", sessionUrl, "image/jpeg", artworkBytes)
+        }
+    }
+
+    fun sendProgress(positionMs: Long, durationMs: Long) {
+        val start = 0L
+        val current = (positionMs * sampleRate / 1000L) + rtpTimestamp
+        val end = (durationMs * sampleRate / 1000L)
+        val body = "progress: $start/$current/$end\r\n".toByteArray(Charsets.UTF_8)
+        sendRtspRequest("SET_PARAMETER", sessionUrl, "text/parameters", body)
+    }
+
+    private fun connectEventPort() {
+        if (eventPort <= 0) return
+        try {
+            val s = Socket()
+            s.connect(InetSocketAddress(host, eventPort), 5000)
+            eventSocket = s
+            startEventReadLoop(s)
+            Log.d(TAG, "Event port $eventPort connected")
+        } catch (e: Exception) {
+            Log.w(TAG, "Event port connect failed: ${e.message}")
+        }
+    }
+
+    private fun startEventReadLoop(s: Socket) {
+        thread(name = "ap2-event", isDaemon = true) {
+            try {
+                val br = s.getInputStream().bufferedReader(Charsets.UTF_8)
+                while (running) {
+                    val line = br.readLine() ?: break
+                    Log.d(TAG, "Event: $line")
+                }
+            } catch (e: Exception) {
+                if (running) Log.w(TAG, "Event loop ended: ${e.message}")
+            }
+        }
+    }
+
     fun close() {
         running = false
         syncThread?.interrupt()
         keepAliveThread?.interrupt()
         if (alacHandle != 0L) { nativeAlac.destroyEncoder(alacHandle); alacHandle = 0L }
         audioSocket?.close()
+        try { eventSocket?.close() } catch (_: Exception) {}
         controlSocket.close()
         timingSocket.close()
         try { socket.close() } catch (_: Exception) {}

--- a/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
+++ b/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
@@ -29,10 +29,17 @@ class AirPlay2Client(
     private val password: String? = null,
     private val txtPk: ByteArray? = null
 ) {
+    interface EventListener {
+        fun onVolumeChange(db: Double) {}
+        fun onRemoteCommand(command: String) {}
+    }
+
     companion object {
         private const val TAG = "AirPlay2Client"
         private const val PUBKEY_3072_SIZE = 384
     }
+
+    var eventListener: EventListener? = null
 
     private val secureRandom = SecureRandom()
     private val socket = Socket()
@@ -565,14 +572,85 @@ class AirPlay2Client(
     private fun startEventReadLoop(s: Socket) {
         thread(name = "ap2-event", isDaemon = true) {
             try {
-                val br = s.getInputStream().bufferedReader(Charsets.UTF_8)
+                val input = s.getInputStream()
                 while (running) {
-                    val line = br.readLine() ?: break
-                    Log.d(TAG, "Event: $line")
+                    val msg = readEventMessage(input) ?: break
+                    dispatchEventMessage(msg)
                 }
             } catch (e: Exception) {
                 if (running) Log.w(TAG, "Event loop ended: ${e.message}")
             }
+        }
+    }
+
+    private data class EventMessage(val method: String, val headers: Map<String, String>, val body: ByteArray?)
+
+    private fun readEventMessage(input: InputStream): EventMessage? {
+        val headerLines = mutableListOf<String>()
+        val buf = StringBuilder()
+        while (true) {
+            val b = input.read()
+            if (b < 0) return null
+            buf.append(b.toChar())
+            if (b == '\n'.code) {
+                val line = buf.toString().trimEnd('\r', '\n')
+                buf.clear()
+                if (line.isEmpty()) break
+                headerLines.add(line)
+            }
+        }
+        if (headerLines.isEmpty()) return null
+        val method = headerLines[0].substringBefore(' ')
+        val headers = linkedMapOf<String, String>()
+        var contentLength = 0
+        for (i in 1 until headerLines.size) {
+            val parts = headerLines[i].split(":", limit = 2)
+            if (parts.size == 2) {
+                val key = parts[0].trim()
+                val value = parts[1].trim()
+                headers[key] = value
+                if (key.equals("Content-Length", ignoreCase = true)) {
+                    contentLength = value.toIntOrNull() ?: 0
+                }
+            }
+        }
+        var body: ByteArray? = null
+        if (contentLength > 0) {
+            body = ByteArray(contentLength)
+            var offset = 0
+            while (offset < contentLength) {
+                val read = input.read(body, offset, contentLength - offset)
+                if (read < 0) break
+                offset += read
+            }
+        }
+        return EventMessage(method, headers, body)
+    }
+
+    private fun dispatchEventMessage(msg: EventMessage) {
+        Log.d(TAG, "Event: ${msg.method} ct=${msg.headers["Content-Type"]}")
+        val body = msg.body ?: return
+        if (msg.headers["Content-Type"]?.contains("apple-binary-plist") != true) return
+        try {
+            val dict = BinaryPlist.decode(body)
+            when (dict["type"]) {
+                "volume" -> {
+                    val db = when (val v = dict["value"]) {
+                        is Double -> v
+                        is Long -> v.toDouble()
+                        else -> return
+                    }
+                    Log.d(TAG, "Event volume: $db dB")
+                    eventListener?.onVolumeChange(db)
+                }
+                "command" -> {
+                    val name = dict["name"] as? String ?: return
+                    Log.d(TAG, "Event command: $name")
+                    eventListener?.onRemoteCommand(name)
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Event dispatch failed: ${e.message}")
         }
     }
 

--- a/app/src/test/java/com/aria/ariacast/airplay2/AirPlay2CryptoTest.kt
+++ b/app/src/test/java/com/aria/ariacast/airplay2/AirPlay2CryptoTest.kt
@@ -1,0 +1,173 @@
+package com.aria.ariacast.airplay2
+
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters
+import org.junit.Assert.*
+import org.junit.Test
+
+class AirPlay2CryptoTest {
+
+    // --- ChaCha20-Poly1305 ---
+
+    @Test
+    fun `chacha20 poly1305 encrypt then decrypt round trip`() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { (it + 1).toByte() }
+        val plaintext = "Hello AirPlay 2".toByteArray(Charsets.UTF_8)
+        val aad = byteArrayOf(0x01, 0x02, 0x03)
+
+        val (ct, tag) = AirPlay2Crypto.chacha20Poly1305Encrypt(key, nonce, plaintext, aad)
+        val decrypted = AirPlay2Crypto.chacha20Poly1305Decrypt(key, nonce, ct, aad, tag)
+
+        assertArrayEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `chacha20 poly1305 ciphertext differs from plaintext`() {
+        val key = ByteArray(32) { 0x42 }
+        val nonce = ByteArray(12)
+        val plaintext = ByteArray(64) { it.toByte() }
+
+        val (ct, _) = AirPlay2Crypto.chacha20Poly1305Encrypt(key, nonce, plaintext, ByteArray(0))
+        assertFalse(plaintext.contentEquals(ct))
+    }
+
+    @Test
+    fun `chacha20 poly1305 tag is 16 bytes`() {
+        val (_, tag) = AirPlay2Crypto.chacha20Poly1305Encrypt(
+            ByteArray(32), ByteArray(12), ByteArray(32), ByteArray(0))
+        assertEquals(16, tag.size)
+    }
+
+    @Test
+    fun `chacha20 poly1305 wrong key fails decryption`() {
+        val key = ByteArray(32)
+        val nonce = ByteArray(12)
+        val plaintext = "secret".toByteArray()
+        val (ct, tag) = AirPlay2Crypto.chacha20Poly1305Encrypt(key, nonce, plaintext, ByteArray(0))
+        try {
+            AirPlay2Crypto.chacha20Poly1305Decrypt(ByteArray(32) { 0xFF.toByte() }, nonce, ct, ByteArray(0), tag)
+            fail("Expected authentication failure")
+        } catch (e: Exception) { /* expected */ }
+    }
+
+    @Test
+    fun `chacha20 poly1305 empty plaintext round trips`() {
+        val key = ByteArray(32) { 0x11 }
+        val nonce = ByteArray(12) { 0x22.toByte() }
+        val (ct, tag) = AirPlay2Crypto.chacha20Poly1305Encrypt(key, nonce, ByteArray(0), ByteArray(0))
+        val decrypted = AirPlay2Crypto.chacha20Poly1305Decrypt(key, nonce, ct, ByteArray(0), tag)
+        assertArrayEquals(ByteArray(0), decrypted)
+    }
+
+    // --- HKDF ---
+
+    @Test
+    fun `hkdf produces correct output lengths`() {
+        val ikm = ByteArray(32) { 0x0B }
+        val salt = "Pair-Verify-AES-Key".toByteArray(Charsets.UTF_8)
+        val info = "Control-Write-Encryption-Key".toByteArray(Charsets.UTF_8)
+        assertEquals(32, AirPlay2Crypto.hkdfSha512(salt, ikm, info, 32).size)
+        assertEquals(64, AirPlay2Crypto.hkdfSha512(salt, ikm, info, 64).size)
+    }
+
+    @Test
+    fun `hkdf different salts produce different outputs`() {
+        val ikm = ByteArray(32) { 0x42 }
+        val info = "test-info".toByteArray(Charsets.UTF_8)
+        val out1 = AirPlay2Crypto.hkdfSha512("Pair-Verify-AES-Key".toByteArray(), ikm, info, 32)
+        val out2 = AirPlay2Crypto.hkdfSha512("Pair-Setup-AES-Key".toByteArray(), ikm, info, 32)
+        assertFalse(out1.contentEquals(out2))
+    }
+
+    @Test
+    fun `hkdf is deterministic`() {
+        val ikm = ByteArray(32) { 0x7F }
+        val salt = "salt".toByteArray()
+        val info = "info".toByteArray()
+        assertArrayEquals(
+            AirPlay2Crypto.hkdfSha512(salt, ikm, info, 32),
+            AirPlay2Crypto.hkdfSha512(salt, ikm, info, 32)
+        )
+    }
+
+    // --- Ed25519 ---
+
+    @Test
+    fun `ed25519 sign and verify round trip`() {
+        val kp = AirPlay2Crypto.generateEd25519KeyPair()
+        val msg = "AirPlay 2 pairing".toByteArray(Charsets.UTF_8)
+        val sig = AirPlay2Crypto.ed25519Sign(kp, msg)
+        assertTrue(AirPlay2Crypto.ed25519Verify(AirPlay2Crypto.getEd25519PublicKey(kp), msg, sig))
+        assertEquals(64, sig.size)
+    }
+
+    @Test
+    fun `ed25519 wrong public key fails verification`() {
+        val kp1 = AirPlay2Crypto.generateEd25519KeyPair()
+        val kp2 = AirPlay2Crypto.generateEd25519KeyPair()
+        val msg = "test".toByteArray()
+        val sig = AirPlay2Crypto.ed25519Sign(kp1, msg)
+        assertFalse(AirPlay2Crypto.ed25519Verify(AirPlay2Crypto.getEd25519PublicKey(kp2), msg, sig))
+    }
+
+    @Test
+    fun `ed25519 tampered message fails verification`() {
+        val kp = AirPlay2Crypto.generateEd25519KeyPair()
+        val sig = AirPlay2Crypto.ed25519Sign(kp, "original".toByteArray())
+        assertFalse(AirPlay2Crypto.ed25519Verify(AirPlay2Crypto.getEd25519PublicKey(kp), "tampered".toByteArray(), sig))
+    }
+
+    @Test
+    fun `ed25519 public key is 32 bytes`() {
+        val kp = AirPlay2Crypto.generateEd25519KeyPair()
+        assertEquals(32, AirPlay2Crypto.getEd25519PublicKey(kp).size)
+    }
+
+    // --- Curve25519 ---
+
+    @Test
+    fun `curve25519 key agreement is symmetric`() {
+        val kp1 = AirPlay2Crypto.generateCurve25519KeyPair()
+        val kp2 = AirPlay2Crypto.generateCurve25519KeyPair()
+        val shared1 = AirPlay2Crypto.curve25519Agree(
+            kp1.private as X25519PrivateKeyParameters, AirPlay2Crypto.getPublicKeyBytes(kp2))
+        val shared2 = AirPlay2Crypto.curve25519Agree(
+            kp2.private as X25519PrivateKeyParameters, AirPlay2Crypto.getPublicKeyBytes(kp1))
+        assertArrayEquals(shared1, shared2)
+        assertEquals(32, shared1.size)
+    }
+
+    // --- Nonce regression ---
+
+    @Test
+    fun `counter nonce does not repeat after 16-bit sequence wrap`() {
+        fun counterNonce(counter: Long): ByteArray {
+            val n = ByteArray(12)
+            for (i in 0..7) n[4 + i] = ((counter shr (i * 8)) and 0xFF).toByte()
+            return n
+        }
+        fun oldSeqNonce(seq: Int): ByteArray {
+            val n = ByteArray(12)
+            n[4] = ((seq shr 8) and 0xFF).toByte()
+            n[5] = (seq and 0xFF).toByte()
+            return n
+        }
+
+        // Counter-based nonces never repeat at the 16-bit boundary
+        assertFalse(counterNonce(0).contentEquals(counterNonce(65536)))
+        assertFalse(counterNonce(65535).contentEquals(counterNonce(65536)))
+
+        // Regression proof: old sequence nonce repeats at 65536 (65536 & 0xFFFF = 0)
+        assertTrue("Old nonce wraps at 65536", oldSeqNonce(0).contentEquals(oldSeqNonce(65536 and 0xFFFF)))
+    }
+
+    // --- PairKeysResult ---
+
+    @Test
+    fun `PairKeysResult counter increments atomically`() {
+        val keys = AirPlay2Crypto.PairKeysResult(ByteArray(32), ByteArray(32), 0L, 0L)
+        assertEquals(0L, keys.encryptionCounter++)
+        assertEquals(1L, keys.encryptionCounter++)
+        assertEquals(2L, keys.encryptionCounter)
+    }
+}

--- a/app/src/test/java/com/aria/ariacast/airplay2/BinaryPlistTest.kt
+++ b/app/src/test/java/com/aria/ariacast/airplay2/BinaryPlistTest.kt
@@ -1,0 +1,82 @@
+package com.aria.ariacast.airplay2
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class BinaryPlistTest {
+
+    @Test
+    fun `encode and decode round-trip simple strings`() {
+        val input = mapOf("title" to "Test Track", "artist" to "Test Artist")
+        val decoded = BinaryPlist.decode(BinaryPlist.encode(input))
+        assertEquals("Test Track", decoded["title"])
+        assertEquals("Test Artist", decoded["artist"])
+    }
+
+    @Test
+    fun `encode and decode round-trip with long string`() {
+        val longString = "A".repeat(20) // > 15 chars exercises extended length encoding
+        val decoded = BinaryPlist.decode(BinaryPlist.encode(mapOf("key" to longString)))
+        assertEquals(longString, decoded["key"])
+    }
+
+    @Test
+    fun `encode and decode round-trip with Long values`() {
+        val input = mapOf("port" to 7000L, "zero" to 0L, "big" to 70000L)
+        val decoded = BinaryPlist.decode(BinaryPlist.encode(input))
+        assertEquals(7000L, decoded["port"])
+        assertEquals(0L, decoded["zero"])
+        assertEquals(70000L, decoded["big"])
+    }
+
+    @Test
+    fun `encode and decode round-trip with ByteArray value`() {
+        val data = byteArrayOf(0x01, 0x02, 0x03, 0xFF.toByte(), 0xAB.toByte())
+        val decoded = BinaryPlist.decode(BinaryPlist.encode(mapOf("raw" to data)))
+        assertArrayEquals(data, decoded["raw"] as? ByteArray)
+    }
+
+    @Test
+    fun `encode and decode empty ByteArray`() {
+        val decoded = BinaryPlist.decode(BinaryPlist.encode(mapOf("empty" to ByteArray(0))))
+        assertArrayEquals(ByteArray(0), decoded["empty"] as? ByteArray)
+    }
+
+    @Test
+    fun `multiple DMAP keys round-trip`() {
+        val input = linkedMapOf<String, Any?>(
+            "dmap.itemname" to "Song Title",
+            "daap.songartist" to "Artist Name",
+            "daap.songalbum" to "Album Name"
+        )
+        val decoded = BinaryPlist.decode(BinaryPlist.encode(input))
+        assertEquals("Song Title", decoded["dmap.itemname"])
+        assertEquals("Artist Name", decoded["daap.songartist"])
+        assertEquals("Album Name", decoded["daap.songalbum"])
+    }
+
+    @Test
+    fun `encoded bytes start with bplist00 magic`() {
+        val encoded = BinaryPlist.encode(mapOf("k" to "v"))
+        assertEquals("bplist00", encoded.copyOf(8).toString(Charsets.UTF_8))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `decode fails on non-plist data`() {
+        BinaryPlist.decode("not a plist".toByteArray())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `decode fails on too short data`() {
+        BinaryPlist.decode(ByteArray(10))
+    }
+
+    @Test
+    fun `makeSessionPlist produces valid plist with required keys`() {
+        val uuid = java.util.UUID.randomUUID()
+        val decoded = BinaryPlist.decode(BinaryPlist.makeSessionPlist(uuid, "AA:BB:CC:DD:EE:FF", 12345))
+        assertEquals("AA:BB:CC:DD:EE:FF", decoded["deviceID"])
+        assertEquals(12345L, decoded["timingPort"])
+        assertEquals("NTP", decoded["timingProtocol"])
+    }
+}

--- a/app/src/test/java/com/aria/ariacast/airplay2/SRP6aClientTest.kt
+++ b/app/src/test/java/com/aria/ariacast/airplay2/SRP6aClientTest.kt
@@ -1,0 +1,96 @@
+package com.aria.ariacast.airplay2
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class SRP6aClientTest {
+
+    @Test
+    fun `buildM1 contains STATE=1 and METHOD=0`() {
+        val srp = SRP6aClient("3939")
+        val parsed = TlvUtil.parse(srp.buildM1())
+        assertEquals(1.toByte(), parsed[TlvUtil.TLV_STATE]?.firstOrNull()?.get(0))
+        assertEquals(0.toByte(), parsed[TlvUtil.TLV_METHOD]?.firstOrNull()?.get(0))
+    }
+
+    @Test
+    fun `buildM1 contains no unexpected TLV types`() {
+        val srp = SRP6aClient("1234")
+        val parsed = TlvUtil.parse(srp.buildM1())
+        assertTrue(parsed.keys.all { it == TlvUtil.TLV_STATE || it == TlvUtil.TLV_METHOD })
+    }
+
+    @Test
+    fun `sharedKeyBytes is null before pairing`() {
+        assertNull(SRP6aClient("3939").sharedKeyBytes)
+    }
+
+    @Test
+    fun `processM2 returns null when state byte is wrong`() {
+        val srp = SRP6aClient("3939")
+        srp.buildM1()
+        val fakeM2 = TlvUtil.build(
+            TlvUtil.TLV_STATE to byteArrayOf(5),         // wrong state (should be 2)
+            TlvUtil.TLV_SALT to ByteArray(16),
+            TlvUtil.TLV_PUBLIC_KEY to ByteArray(384) { 0x42 }
+        )
+        assertNull(srp.processM2(fakeM2))
+    }
+
+    @Test
+    fun `processM2 returns null when salt is wrong size`() {
+        val srp = SRP6aClient("3939")
+        srp.buildM1()
+        val fakeM2 = TlvUtil.build(
+            TlvUtil.TLV_STATE to byteArrayOf(2),
+            TlvUtil.TLV_SALT to ByteArray(8),            // should be 16 bytes
+            TlvUtil.TLV_PUBLIC_KEY to ByteArray(384) { 0x42 }
+        )
+        assertNull(srp.processM2(fakeM2))
+    }
+
+    @Test
+    fun `processM2 returns null on empty body`() {
+        val srp = SRP6aClient("3939")
+        srp.buildM1()
+        assertNull(srp.processM2(ByteArray(0)))
+    }
+
+    @Test
+    fun `verifyM4 returns false on wrong proof`() {
+        val srp = SRP6aClient("3939")
+        srp.buildM1()
+        // Synthesize a fake M2 with correct state and sizes so processM2 proceeds
+        val fakeM2 = TlvUtil.build(
+            TlvUtil.TLV_STATE to byteArrayOf(2),
+            TlvUtil.TLV_SALT to ByteArray(16) { it.toByte() },
+            TlvUtil.TLV_PUBLIC_KEY to ByteArray(384) { 0x42 }
+        )
+        val m3 = srp.processM2(fakeM2) // runs SRP math on fake B
+        assertNotNull("processM2 should succeed with valid sizes", m3)
+
+        // Now send a wrong M4 (random proof)
+        val fakeM4 = TlvUtil.build(
+            TlvUtil.TLV_STATE to byteArrayOf(4),
+            TlvUtil.TLV_PROOF to ByteArray(64) { 0xFF.toByte() } // wrong proof
+        )
+        assertFalse(srp.verifyM4(fakeM4))
+    }
+
+    @Test
+    fun `buildM1 result is parseable as TLV`() {
+        val srp = SRP6aClient("0000")
+        val m1 = srp.buildM1()
+        val parsed = TlvUtil.parse(m1)
+        assertFalse(parsed.isEmpty())
+    }
+
+    @Test
+    fun `different pins produce same M1 structure`() {
+        // M1 is always the same structure regardless of PIN (PIN is used in M3)
+        val m1a = TlvUtil.parse(SRP6aClient("1234").buildM1())
+        val m1b = TlvUtil.parse(SRP6aClient("5678").buildM1())
+        assertArrayEquals(m1a[TlvUtil.TLV_STATE]?.firstOrNull(), m1b[TlvUtil.TLV_STATE]?.firstOrNull())
+        assertArrayEquals(m1a[TlvUtil.TLV_METHOD]?.firstOrNull(), m1b[TlvUtil.TLV_METHOD]?.firstOrNull())
+    }
+}

--- a/app/src/test/java/com/aria/ariacast/airplay2/TlvUtilTest.kt
+++ b/app/src/test/java/com/aria/ariacast/airplay2/TlvUtilTest.kt
@@ -1,0 +1,98 @@
+package com.aria.ariacast.airplay2
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class TlvUtilTest {
+
+    @Test
+    fun `build and parse single entry`() {
+        val data = byteArrayOf(1, 2, 3)
+        val parsed = TlvUtil.parse(TlvUtil.build(TlvUtil.TLV_STATE to data))
+        assertArrayEquals(data, parsed[TlvUtil.TLV_STATE]?.firstOrNull())
+    }
+
+    @Test
+    fun `build and parse multiple entries`() {
+        val state = byteArrayOf(1)
+        val method = byteArrayOf(0)
+        val parsed = TlvUtil.parse(TlvUtil.build(
+            TlvUtil.TLV_STATE to state,
+            TlvUtil.TLV_METHOD to method
+        ))
+        assertArrayEquals(state, parsed[TlvUtil.TLV_STATE]?.firstOrNull())
+        assertArrayEquals(method, parsed[TlvUtil.TLV_METHOD]?.firstOrNull())
+    }
+
+    @Test
+    fun `build and parse empty value`() {
+        val parsed = TlvUtil.parse(TlvUtil.build(TlvUtil.TLV_FLAGS to ByteArray(0)))
+        assertArrayEquals(ByteArray(0), parsed[TlvUtil.TLV_FLAGS]?.firstOrNull())
+    }
+
+    @Test
+    fun `getFirst returns correct value`() {
+        val pk = ByteArray(32) { it.toByte() }
+        val built = TlvUtil.build(
+            TlvUtil.TLV_STATE to byteArrayOf(2),
+            TlvUtil.TLV_PUBLIC_KEY to pk
+        )
+        assertArrayEquals(pk, TlvUtil.getFirst(built, TlvUtil.TLV_PUBLIC_KEY))
+    }
+
+    @Test
+    fun `getFirst returns null for missing type`() {
+        val built = TlvUtil.build(TlvUtil.TLV_STATE to byteArrayOf(1))
+        assertNull(TlvUtil.getFirst(built, TlvUtil.TLV_SIGNATURE))
+    }
+
+    @Test
+    fun `parse handles 384-byte public key`() {
+        val bigValue = ByteArray(384) { (it and 0xFF).toByte() }
+        val parsed = TlvUtil.parse(TlvUtil.build(TlvUtil.TLV_PUBLIC_KEY to bigValue))
+        assertArrayEquals(bigValue, parsed[TlvUtil.TLV_PUBLIC_KEY]?.firstOrNull())
+    }
+
+    @Test
+    fun `parse empty bytes returns empty map`() {
+        assertTrue(TlvUtil.parse(ByteArray(0)).isEmpty())
+    }
+
+    @Test
+    fun `wire format header is type then 2-byte big-endian length`() {
+        val value = byteArrayOf(0x12, 0x34, 0x56)
+        val built = TlvUtil.build(TlvUtil.TLV_PROOF to value)
+        assertEquals(TlvUtil.TLV_PROOF, built[0].toInt() and 0xFF)
+        assertEquals(0, built[1].toInt() and 0xFF)  // length high byte
+        assertEquals(3, built[2].toInt() and 0xFF)  // length low byte
+        assertEquals(0x12.toByte(), built[3])
+        assertEquals(0x34.toByte(), built[4])
+        assertEquals(0x56.toByte(), built[5])
+    }
+
+    @Test
+    fun `buildSingle produces identical result to build with one entry`() {
+        val value = ByteArray(16) { 0xAB.toByte() }
+        val viaMulti = TlvUtil.build(TlvUtil.TLV_ENCRYPTED_DATA to value)
+        val viaSingle = TlvUtil.buildSingle(TlvUtil.TLV_ENCRYPTED_DATA, value)
+        assertArrayEquals(viaMulti, viaSingle)
+    }
+
+    @Test
+    fun `round-trip preserves all known TLV types`() {
+        val types = listOf(
+            TlvUtil.TLV_METHOD,
+            TlvUtil.TLV_IDENTIFIER,
+            TlvUtil.TLV_SALT,
+            TlvUtil.TLV_PUBLIC_KEY,
+            TlvUtil.TLV_STATE,
+            TlvUtil.TLV_SIGNATURE
+        )
+        val pairs = types.mapIndexed { i, t -> t to byteArrayOf(i.toByte()) }.toTypedArray()
+        val built = TlvUtil.build(*pairs)
+        val parsed = TlvUtil.parse(built)
+        types.forEachIndexed { i, t ->
+            assertArrayEquals("TLV type $t", byteArrayOf(i.toByte()), parsed[t]?.firstOrNull())
+        }
+    }
+}


### PR DESCRIPTION
- P0-1: Replace 16-bit RTP sequence nonce with 64-bit counter to prevent
  nonce reuse after ~7.7 min of playback (ChaCha20-Poly1305 correctness)
- P0-2: Capture cipherKeys reference before null check to eliminate TOCTOU
  race between sendAudioFrame and close()
- P0-3/P1-1: Implement sendMetadata() on AirPlay2Client; sends title/artist/
  album as binary plist via SET_PARAMETER, plus artwork as image/jpeg
- P0-4: Track per-device volume state in AudioCastService; volume steps ±3 dB
  instead of snapping between two fixed values
- P0-5: Fix parseSessionResponse() to decode binary plist instead of UTF-8
  regex; store eventPort; open TCP event socket after RECORD and read events
- P1-2: Fix sample rate mismatch — AirPlay2 now forces 44100 Hz to match
  what AirPlay2Client negotiates, preventing wrong-pitch audio
- P2-2: Wrap IPv6 addresses in brackets when building RTSP session URL
- P2-3: Implement sendProgress() for playback position/duration metadata

https://claude.ai/code/session_01ETFxpdZs2teXP7giAH5y7T