### PR TITLE
Skip audio handshake for AriaCast platform destinations

### DIFF
--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -1099,13 +1099,15 @@ class AudioCastService : Service() {
                 client.webSocket(host = dest.host, port = dest.port, path = "/audio") audioSocket@{
                     reconnectAttempts = 0
                     
-                    val handshakeFrame = try {
-                        withTimeout(3000L) { incoming.receive() }
-                    } catch (e: Exception) {
-                        return@audioSocket
-                    }
+                    if (dest.platform != "AriaCast") {
+                        val handshakeFrame = try {
+                            withTimeout(3000L) { incoming.receive() }
+                        } catch (e: Exception) {
+                            return@audioSocket
+                        }
 
-                    if (handshakeFrame !is Frame.Text) return@audioSocket
+                        if (handshakeFrame !is Frame.Text) return@audioSocket
+                    }
 
                     _state.value = CastState.CASTING
                     updateNotification()


### PR DESCRIPTION
The AriaCast Android receiver does not send an initial text handshake
frame on /audio, causing the sender to time out and abort every
connection attempt silently.

https://claude.ai/code/session_016pCrWZmL8WkBmSJhx7s2Dh