### PR TITLE
Fix AriaCast Android receiver audio output

### DIFF
--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -1762,8 +1762,8 @@ class AudioCastService : Service() {
         const val KEY_LAST_SERVER_PORT = "last_server_port"
         const val KEY_LAST_SERVER_NAME = "last_server_name"
 
-        const val SAMPLE_RATE = 44100
-        const val FRAME_SIZE = 3528
+        const val SAMPLE_RATE = 48000
+        const val FRAME_SIZE = 3840
         const val LATENCY = 66150
         private const val AP2_ALAC_FRAME_SIZE = 352  // ALAC frame size in samples for AirPlay 2
         


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Skip the WebSocket handshake wait for `AriaCast` platform destinations — the Android receiver never sends an initial text frame, causing the sender to time out and silently abort every connection attempt
- Fix sample rate mismatch: sender was capturing at 44100 Hz (`FRAME_SIZE=3528`) while the Android receiver expects 48000 Hz (`FRAME_SIZE=3840`)

## Test plan

- [ ] Connect AriaCast app to an AriaCast Android receiver — audio should stream without delay
- [ ] Verify other platform destinations (DLNA, AirPlay, AirPlay2, Google Cast) still require and receive the handshake correctly
- [ ] Confirm audio plays back at the correct pitch/speed (no resampling artifacts from the 44.1→48 kHz fix)

https://claude.ai/code/session_016pCrWZmL8WkBmSJhx7s2Dh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016pCrWZmL8WkBmSJhx7s2Dh)_