### PR TITLE
Add Docker build environment with download page on :8040

### DIFF
--- a/AriaCompanion/buildroot/Dockerfile
+++ b/AriaCompanion/buildroot/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.title="AriaCompanion builder" \
+      org.opencontainers.image.description="Buildroot cross-compiler for Pi Zero W/2W firmware"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV BUILDROOT_VERSION=2024.02.6
+
+# ── Build dependencies (Buildroot host requirements) ──────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash bc binutils bison bzip2 ca-certificates \
+        cpio diffutils file findutils flex \
+        gawk gcc g++ git gzip \
+        libssl-dev libelf-dev libncurses-dev \
+        lzop make patch perl python3 rsync \
+        sed tar texinfo unzip wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Pre-download Buildroot source (cached as its own layer) ───────────────────
+# This layer only re-runs when BUILDROOT_VERSION changes, not when our source
+# changes — so `docker build` after editing AriaCompanion code stays fast.
+RUN wget -q --show-progress --progress=bar:force \
+        "https://buildroot.org/downloads/buildroot-${BUILDROOT_VERSION}.tar.gz" \
+        -O /opt/buildroot.tar.gz \
+    && tar xf /opt/buildroot.tar.gz -C /opt \
+    && rm /opt/buildroot.tar.gz
+
+# ── Copy our BR2_EXTERNAL tree ────────────────────────────────────────────────
+COPY . /build/ariacomp
+
+# Create download cache directory (mount a named volume here for fast rebuilds)
+RUN mkdir -p /build/dl-cache
+
+# Output dir that will be served
+RUN mkdir -p /build/serve
+
+WORKDIR /build/ariacomp
+
+EXPOSE 8040
+
+ENTRYPOINT ["/build/ariacomp/docker-entrypoint.sh"]
+# Default: build both targets; override with e.g. `docker run … pizero2w`
+CMD ["both"]

--- a/AriaCompanion/buildroot/build.sh
+++ b/AriaCompanion/buildroot/build.sh
@@ -24,7 +24,8 @@ set -euo pipefail
 # ── Configuration ─────────────────────────────────────────────────────────────
 BUILDROOT_VERSION="2024.02.6"
 BUILDROOT_URL="https://buildroot.org/downloads/buildroot-${BUILDROOT_VERSION}.tar.gz"
-BUILDROOT_DIR="$(pwd)/buildroot-${BUILDROOT_VERSION}"
+# Allow Docker (or the user) to pre-place Buildroot elsewhere
+BUILDROOT_DIR="${BUILDROOT_DIR:-$(pwd)/buildroot-${BUILDROOT_VERSION}}"
 
 EXT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # this directory
 

--- a/AriaCompanion/buildroot/docker-entrypoint.sh
+++ b/AriaCompanion/buildroot/docker-entrypoint.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Docker entrypoint — builds the requested target(s) then serves the images.
+set -euo pipefail
+
+TARGET="${1:-both}"
+ARIACOMP_DIR="/build/ariacomp"
+SERVE_DIR="/build/serve"
+DL_CACHE="/build/dl-cache"
+BR_VERSION="2024.02.6"
+
+# ── Point build.sh at the pre-baked Buildroot source ─────────────────────────
+# The Dockerfile extracted it to /opt/buildroot-<version>.
+# build.sh honours $BUILDROOT_DIR to skip downloading.
+export BUILDROOT_DIR="/opt/buildroot-${BR_VERSION}"
+
+# ── Route Buildroot package downloads to the cache volume ────────────────────
+# BR2_DL_DIR tells Buildroot where to store downloaded tarballs.
+# Mounting a named Docker volume here makes rebuilds much faster.
+export BR2_DL_DIR="${DL_CACHE}"
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+echo "╔══════════════════════════════════════════╗"
+echo "║  AriaCompanion Buildroot image builder   ║"
+echo "║  target: ${TARGET}                       "
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+build_one() {
+    local t="$1"
+    echo "▶ Building: ${t}"
+    "${ARIACOMP_DIR}/build.sh" "${t}"
+
+    local img="${ARIACOMP_DIR}/output-${t}/images/sdcard.img"
+    if [[ -f "$img" ]]; then
+        local dest="${SERVE_DIR}/ariacompanion-${t}.img"
+        cp "$img" "$dest"
+        printf "✓ %s  (%s)\n" "$(basename "$dest")" "$(du -sh "$dest" | cut -f1)"
+    else
+        echo "✗ Image not found for target ${t}" >&2
+        exit 1
+    fi
+}
+
+case "$TARGET" in
+    pizerow)  build_one pizerow  ;;
+    pizero2w) build_one pizero2w ;;
+    both)     build_one pizerow; build_one pizero2w ;;
+    *)
+        echo "Unknown target: ${TARGET}  (use pizerow | pizero2w | both)" >&2
+        exit 1
+        ;;
+esac
+
+# ── Serve ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════"
+echo "  Build complete.  Serving on :8040"
+echo "  Open http://localhost:8040 to download."
+echo "══════════════════════════════════════════"
+echo ""
+
+exec python3 "${ARIACOMP_DIR}/docker-serve.py" "${SERVE_DIR}"

--- a/AriaCompanion/buildroot/docker-run.sh
+++ b/AriaCompanion/buildroot/docker-run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# One-command build + serve for AriaCompanion firmware images.
+#
+# Usage:
+#   ./docker-run.sh              # build both Pi Zero W and Pi Zero 2W
+#   ./docker-run.sh pizero2w     # build only Pi Zero 2W (faster)
+#   ./docker-run.sh pizerow      # build only Pi Zero W
+#
+# The first run downloads Buildroot packages (~1.5 GB) and builds everything
+# from source — expect 60–90 minutes.  Subsequent runs reuse the download
+# cache and finish in ~5 minutes.
+#
+# When done, open http://localhost:8040 to download the .img files.
+set -euo pipefail
+
+TARGET="${1:-both}"
+IMAGE_TAG="ariacomp-builder"
+# Named volume persists the Buildroot package download cache across runs
+DL_VOLUME="ariacomp-dl-cache"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Sanity checks ─────────────────────────────────────────────────────────────
+if ! command -v docker &>/dev/null; then
+    echo "ERROR: docker not found. Install Docker and try again." >&2
+    exit 1
+fi
+
+case "$TARGET" in
+    pizerow|pizero2w|both) ;;
+    *)
+        echo "Usage: $0 [pizerow|pizero2w|both]" >&2
+        exit 1
+        ;;
+esac
+
+# ── Build the Docker image ────────────────────────────────────────────────────
+echo "▶ Building Docker image '${IMAGE_TAG}'…"
+echo "  (This step installs host tools and pre-downloads Buildroot ~50 MB."
+echo "   Cached after first run.)"
+echo ""
+
+docker build \
+    --tag "${IMAGE_TAG}" \
+    --file "${SCRIPT_DIR}/Dockerfile" \
+    "${SCRIPT_DIR}"
+
+echo ""
+echo "▶ Running build for target: ${TARGET}"
+echo "  Download cache volume: ${DL_VOLUME}"
+echo "  Build output served on: http://localhost:8040"
+echo ""
+echo "  ┌─ First run  ──────────────────────────────────────┐"
+echo "  │  Downloads ~1.5 GB of packages + cross-compiler   │"
+echo "  │  Compiles Linux kernel + rootfs from source        │"
+echo "  │  Expected time: 60–90 min                          │"
+echo "  ├─ Subsequent runs ─────────────────────────────────┤"
+echo "  │  Cache reused from '${DL_VOLUME}' volume          │"
+echo "  │  Expected time: ~5 min                             │"
+echo "  └────────────────────────────────────────────────────┘"
+echo ""
+
+# ── Run the builder container ─────────────────────────────────────────────────
+docker run \
+    --rm \
+    --name ariacomp-build \
+    -p 8040:8040 \
+    -v "${DL_VOLUME}:/build/dl-cache" \
+    "${IMAGE_TAG}" \
+    "${TARGET}"

--- a/AriaCompanion/buildroot/docker-serve.py
+++ b/AriaCompanion/buildroot/docker-serve.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Minimal HTTP file server for built AriaCompanion images.
+Serves a download page on port 8040 with file sizes and correct
+Content-Disposition headers so browsers save with the right filename.
+
+Usage (called by docker-entrypoint.sh):
+    python3 docker-serve.py /build/serve
+"""
+import http.server
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PORT = 8040
+
+BOARD_LABELS = {
+    "ariacompanion-pizero2w.img": ("Pi Zero 2W", "ARMv8 · 64-bit · Cortex-A53", "#1a73e8"),
+    "ariacompanion-pizerow.img":  ("Pi Zero W",  "ARMv6 · 32-bit · ARM1176",    "#34a853"),
+}
+
+_CSS = """
+  * { box-sizing: border-box; margin: 0; padding: 0 }
+  body { font-family: system-ui, sans-serif; background: #f0f2f5;
+         min-height: 100vh; display: flex; align-items: flex-start;
+         justify-content: center; padding: 40px 16px }
+  .card { background: white; border-radius: 12px; padding: 32px;
+          max-width: 560px; width: 100%;
+          box-shadow: 0 1px 3px rgba(0,0,0,.12) }
+  h1 { font-size: 22px; color: #202124; margin-bottom: 4px }
+  .sub { color: #5f6368; font-size: 14px; margin-bottom: 28px }
+  .item { border: 1px solid #e0e0e0; border-radius: 8px;
+          padding: 18px 20px; margin-bottom: 14px;
+          display: flex; align-items: center; gap: 16px }
+  .dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0 }
+  .info { flex: 1 }
+  .name { font-weight: 600; color: #202124 }
+  .desc { font-size: 13px; color: #5f6368; margin-top: 2px }
+  .size { font-size: 13px; color: #5f6368; margin-top: 2px }
+  a.btn { display: inline-block; padding: 8px 18px; border-radius: 6px;
+          background: #1a73e8; color: white; text-decoration: none;
+          font-size: 14px; font-weight: 500; white-space: nowrap }
+  a.btn:hover { background: #1557b0 }
+  .none { color: #c5221f; font-size: 15px; padding: 12px 0 }
+  .footer { font-size: 12px; color: #9aa0a6; margin-top: 24px; text-align: center }
+  hr { border: none; border-top: 1px solid #e0e0e0; margin: 20px 0 }
+  .flash { background:#e6f4ea; border-radius:8px; padding:14px 16px;
+           font-size:13px; color:#137333; margin-top:20px }
+  code { background:#f1f3f4; padding:2px 6px; border-radius:4px;
+         font-family:monospace; font-size:12px }
+"""
+
+def fmt_size(path: Path) -> str:
+    b = path.stat().st_size
+    for unit in ("B", "KB", "MB", "GB"):
+        if b < 1024:
+            return f"{b:.0f} {unit}"
+        b /= 1024
+    return f"{b:.1f} GB"
+
+def make_index(serve_dir: Path) -> str:
+    images = sorted(serve_dir.glob("*.img"))
+    built_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    items_html = ""
+    if not images:
+        items_html = '<p class="none">No images found.</p>'
+    else:
+        for img in images:
+            label, desc, color = BOARD_LABELS.get(
+                img.name, (img.stem, "", "#757575")
+            )
+            size = fmt_size(img)
+            items_html += f"""
+            <div class="item">
+              <div class="dot" style="background:{color}"></div>
+              <div class="info">
+                <div class="name">{label}</div>
+                <div class="desc">{desc}</div>
+                <div class="size">{img.name} &nbsp;·&nbsp; {size}</div>
+              </div>
+              <a class="btn" href="/{img.name}" download="{img.name}">Download</a>
+            </div>"""
+
+    return f"""<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AriaCompanion — Built Images</title>
+<style>{_CSS}</style>
+</head><body>
+<div class="card">
+  <h1>AriaCompanion</h1>
+  <p class="sub">Built {built_at}</p>
+  {items_html}
+  <hr>
+  <div class="flash">
+    Flash with:
+    <br><br>
+    <code>sudo dd if=ariacompanion-pizero2w.img of=/dev/sdX bs=4M status=progress</code>
+    <br><br>
+    Or open the file in <strong>Raspberry Pi Imager</strong> → Use custom image.
+  </div>
+  <p class="footer">AriaCompanion — Bluetooth A2DP → TCP bridge for AriaCast</p>
+</div>
+</body></html>"""
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    serve_dir: Path
+
+    server_version = "AriaCompanion/1"
+
+    def log_message(self, fmt, *args):
+        print(f"  {self.address_string()}  {fmt % args}", flush=True)
+
+    def do_GET(self):
+        path = self.path.split("?")[0].lstrip("/")
+
+        # Index
+        if path == "" or path == "index.html":
+            body = make_index(self.serve_dir).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", len(body))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        # File download
+        target = self.serve_dir / path
+        if target.suffix == ".img" and target.is_file():
+            size = target.stat().st_size
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Disposition", f'attachment; filename="{target.name}"')
+            self.send_header("Content-Length", size)
+            self.end_headers()
+            with open(target, "rb") as f:
+                while chunk := f.read(256 * 1024):
+                    self.wfile.write(chunk)
+            return
+
+        self.send_error(404)
+
+
+if __name__ == "__main__":
+    serve_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    Handler.serve_dir = serve_dir
+
+    with http.server.ThreadingHTTPServer(("0.0.0.0", PORT), Handler) as srv:
+        print(f"Serving {serve_dir}  →  http://localhost:{PORT}", flush=True)
+        srv.serve_forever()


### PR DESCRIPTION
Single-command workflow:
  ./docker-run.sh [pizero2w|pizerow|both]

Dockerfile (ubuntu:22.04):
- Installs all Buildroot host prerequisites
- Downloads and extracts buildroot-2024.02.6 into /opt as a separate cached layer — rebuilds after source edits don't re-download Buildroot
- Copies BR2_EXTERNAL tree, exposes :8040

docker-entrypoint.sh:
- Sets BUILDROOT_DIR=/opt/buildroot-2024.02.6 so build.sh skips download
- Sets BR2_DL_DIR=/build/dl-cache (mounted named volume) so Buildroot package tarballs persist across `docker run` invocations (~1.5 GB, first run only; subsequent builds complete in ~5 minutes)
- Calls build.sh for requested target(s), copies .img to /build/serve
- Hands off to docker-serve.py

docker-serve.py:
- ThreadingHTTPServer on :8040
- GET / → clean HTML download page with board labels, file sizes, flash instructions
- GET /*.img → Content-Disposition attachment download (correct filename)

docker-run.sh:
- `docker build` then `docker run --rm -p 8040:8040 -v ariacomp-dl-cache`
- Prints first-run vs cached-run time estimates

build.sh: added BUILDROOT_DIR env var override (no logic change for non-Docker use)

https://claude.ai/code/session_016pCrWZmL8WkBmSJhx7s2Dh