### PR TITLE
Add DiscoveryManager.addManualServer()

### DIFF
--- a/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
+++ b/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
@@ -325,6 +325,34 @@ class DiscoveryManager(private val context: Context) {
         }
     }
 
+    /**
+     * Adds a server that was entered manually (e.g. via the "Manual Server Entry" plugin)
+     * rather than discovered through mDNS/SSDP/UDP. Returns false if the host is not a
+     * valid IP address, true once the server has been merged into [servers].
+     */
+    fun addManualServer(host: String, port: Int, name: String): Boolean {
+        if (!Patterns.IP_ADDRESS.matcher(host).matches()) {
+            Log.w(TAG, "addManualServer: invalid host '$host'")
+            return false
+        }
+        val server = Server(
+            name = name,
+            host = host,
+            port = port,
+            version = "manual",
+            codecs = emptyList(),
+            sampleRate = 48000,
+            channels = 2,
+            platform = "Manual"
+        )
+        synchronized(discoveredServers) {
+            discoveredServers[name] = server
+            _servers.value = discoveredServers.values.toList()
+        }
+        Log.d(TAG, "Manually added server: $name @ $host:$port")
+        return true
+    }
+
     private suspend fun startSsdpDiscoveryLoop() = withContext(Dispatchers.IO) {
         val ssdpAddress = InetAddress.getByName("239.255.255.250")
         val searchTargets = listOf(


### PR DESCRIPTION
## Summary

`manual_server.js` (in `AriaCast-android-plugins`) is a Rhino JS plugin that lets a user type in a server IP by hand when mDNS/UDP discovery doesn't find it. It calls:

```js
discovery.addManualServer(ip, port, "Manual: " + ip)
```

but `DiscoveryManager.kt` only exposed `startDiscovery()`, `stopDiscovery()`, and `removeServer(name: String)` — there was no `addManualServer`. Invoking the plugin crashed with:

```
org.mozilla.javascript.EcmaError: TypeError: Cannot find function addManualServer in object com.aria.ariacast.DiscoveryManager.
```

## Fix

- Added `addManualServer(host: String, port: Int, name: String): Boolean` to `DiscoveryManager.kt`, right after `removeServer()`, using the same `synchronized(discoveredServers)` pattern the rest of the class uses to publish into `_servers`.
- Validates `host` with `Patterns.IP_ADDRESS` (both already imported) and logs + returns `false` on an invalid IP instead of inserting garbage.
- Sets `platform = "Manual"` on the constructed `Server`. This was checked deliberately: `MainActivity.kt`'s `ServerAdapter.onBindViewHolder` already has `if (server.platform == "Manual")` gating the delete button that calls `discoveryManager.removeServer(server.name)`. Using any other platform string (e.g. lowercase `"manual"`) would silently strip users of any way to remove a manually-added entry from the list.
- Verified `version` / `sampleRate` / `channels` / `codecs` placeholder values are inert elsewhere downstream (not read by `AudioCastService`'s `CastDestination`, which only carries `name`/`host`/`port`/`platform`/`extra`), so the placeholder values used by other synthetic entries in this file (48000 Hz, 2 channels, `emptyList()` codecs) are safe to reuse here.

## Test plan

- [ ] Manually invoke the "Manual Server Entry" plugin from the Plugins screen with a valid IP and confirm the server appears in the list with a delete (trash) button instead of crashing.
- [ ] Confirm entering an invalid host (non-IP string) is rejected (method returns `false`, nothing added) instead of throwing.
- [ ] Confirm tapping the delete button on a manually-added server removes it via `removeServer`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015PfWZwyydGDGTbeJaMYxT8)_