### PR TITLE
Add casting diagnostics (Packet Log) + request RECORD_AUDIO/POST_NOTIFICATIONS at runtime

### DIFF
--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -473,6 +473,7 @@ class AudioCastService : Service() {
         } catch (e: Exception) {
             if (e is ForegroundServiceStartNotAllowedException) {
                 Log.e(TAG, "Foreground service start not allowed", e)
+                PacketLogger.log(PacketDirection.IN, PacketType.HANDSHAKE, "Foreground service start not allowed: ${e.message}")
                 _state.value = CastState.ERROR
                 return
             } else {
@@ -484,6 +485,7 @@ class AudioCastService : Service() {
         val projection = mediaProjectionManager.getMediaProjection(Activity.RESULT_OK, mediaProjectionToken)
         if (projection == null) {
             Log.e(TAG, "MediaProjection is null")
+            PacketLogger.log(PacketDirection.IN, PacketType.HANDSHAKE, "MediaProjection permission was not granted")
             _state.value = CastState.ERROR
             return
         }
@@ -523,15 +525,18 @@ class AudioCastService : Service() {
                         initialized = true
                     } else {
                         Log.e(TAG, "AudioRecord not initialized, attempt $attempt")
+                        PacketLogger.log(PacketDirection.IN, PacketType.AUDIO, "AudioRecord not initialized (attempt $attempt)")
                         recorder.release()
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "AudioRecord initialization attempt $attempt failed: ${e.message}")
+                    PacketLogger.log(PacketDirection.IN, PacketType.AUDIO, "AudioRecord init failed (attempt $attempt): ${e.message}")
                 }
             }
 
             if (!initialized) {
                 Log.e(TAG, "Failed to initialize AudioRecord after $attempt attempts")
+                PacketLogger.log(PacketDirection.IN, PacketType.AUDIO, "AudioRecord failed to initialize after $attempt attempts — check Microphone permission for AriaCast")
                 _state.value = CastState.ERROR
                 return@launch
             }
@@ -543,21 +548,35 @@ class AudioCastService : Service() {
                 startArtworkServer()
             }
 
-            launch { 
+            launch {
                 try {
                     audioRecord?.startRecording()
+                    PacketLogger.log(PacketDirection.IN, PacketType.AUDIO, "AudioRecord capture started")
                     val audioBuffer = ByteBuffer.allocate(FRAME_SIZE)
+                    var lastFrameWasSilent: Boolean? = null
                     while (isActive) {
                         val readResult = audioRecord?.read(audioBuffer.array(), 0, FRAME_SIZE) ?: 0
                         if (readResult == FRAME_SIZE) {
-                            _audioBufferFlow.emit(audioBuffer.array().copyOf())
+                            val frame = audioBuffer.array().copyOf()
+                            val isSilent = frame.all { it == 0.toByte() }
+                            if (isSilent != lastFrameWasSilent) {
+                                lastFrameWasSilent = isSilent
+                                PacketLogger.log(
+                                    PacketDirection.IN, PacketType.AUDIO,
+                                    if (isSilent) "Capture is silent — no audio signal detected (check DRM/FLAG_SECURE source, or that something is actually playing)"
+                                    else "Capture is producing a real audio signal"
+                                )
+                            }
+                            _audioBufferFlow.emit(frame)
                         } else if (readResult < 0) {
                             Log.e(TAG, "AudioRecord read error: $readResult")
+                            PacketLogger.log(PacketDirection.IN, PacketType.AUDIO, "AudioRecord read error: $readResult")
                             break
                         }
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "Audio recording loop failed", e)
+                    PacketLogger.log(PacketDirection.IN, PacketType.AUDIO, "Audio recording loop crashed: ${e.message}")
                 }
             }
 
@@ -1207,15 +1226,21 @@ class AudioCastService : Service() {
             try {
                 client.webSocket(host = dest.host, port = dest.port, path = "/audio") audioSocket@{
                     reconnectAttempts = 0
-                    
+                    PacketLogger.log(PacketDirection.OUT, PacketType.HANDSHAKE, "Audio socket connected to ${dest.name} (${dest.host}:${dest.port})")
+
                     if (dest.platform != "AriaCast") {
                         val handshakeFrame = try {
                             withTimeout(3000L) { incoming.receive() }
                         } catch (e: Exception) {
+                            Log.w(TAG, "Audio handshake timed out for ${dest.host}: ${e.message}")
+                            PacketLogger.log(PacketDirection.IN, PacketType.HANDSHAKE, "Handshake timed out for ${dest.name}: ${e.message}")
                             return@audioSocket
                         }
 
-                        if (handshakeFrame !is Frame.Text) return@audioSocket
+                        if (handshakeFrame !is Frame.Text) {
+                            PacketLogger.log(PacketDirection.IN, PacketType.HANDSHAKE, "Unexpected handshake frame type from ${dest.name}")
+                            return@audioSocket
+                        }
                     }
 
                     _state.value = CastState.CASTING
@@ -1252,6 +1277,8 @@ class AudioCastService : Service() {
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
+                Log.e(TAG, "Audio WS connection to ${dest.host}:${dest.port} failed: ${e.message}", e)
+                PacketLogger.log(PacketDirection.IN, PacketType.HANDSHAKE, "Audio connection to ${dest.name} failed: ${e.message ?: e.javaClass.simpleName}")
                 reconnectAttempts++
                 val delayTime = (RECONNECT_INITIAL_BACKOFF * 2.0.pow(reconnectAttempts.toDouble().coerceAtMost(5.0))).toLong()
                 delay(delayTime)
@@ -1261,8 +1288,12 @@ class AudioCastService : Service() {
 
     private fun sendAudioFrame(session: DefaultClientWebSocketSession, buffer: ByteArray) {
         val sent = session.outgoing.trySendBlocking(Frame.Binary(true, buffer))
-        if (!sent.isSuccess) {
+        if (sent.isSuccess) {
+            PacketLogger.log(PacketDirection.OUT, PacketType.AUDIO, "Audio frame sent", buffer.size)
+        } else {
             _stats.value = _stats.value.copy(droppedFrames = _stats.value.droppedFrames + 1)
+            Log.w(TAG, "Audio frame send failed (dropped)")
+            PacketLogger.log(PacketDirection.OUT, PacketType.AUDIO, "Audio frame dropped (send failed)", buffer.size)
         }
     }
 
@@ -1649,6 +1680,7 @@ class AudioCastService : Service() {
             try {
                 client.webSocket(host = dest.host, port = dest.port, path = "/control") {
                     controlSessions[dest.host] = this
+                    PacketLogger.log(PacketDirection.OUT, PacketType.CONTROL, "Control socket connected to ${dest.name}")
                     for (frame in incoming) {
                         if (frame is Frame.Text) {
                             val text = frame.readText()
@@ -1665,6 +1697,8 @@ class AudioCastService : Service() {
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
+                Log.e(TAG, "Control WS connection to ${dest.host}:${dest.port} failed: ${e.message}", e)
+                PacketLogger.log(PacketDirection.IN, PacketType.CONTROL, "Control connection to ${dest.name} failed: ${e.message ?: e.javaClass.simpleName}")
                 controlSessions.remove(dest.host)
                 delay(RECONNECT_INITIAL_BACKOFF)
             }
@@ -1675,6 +1709,7 @@ class AudioCastService : Service() {
         while (currentCoroutineContext().isActive) {
             try {
                 client.webSocket(host = dest.host, port = dest.port, path = "/stats") statsSocket@{
+                    PacketLogger.log(PacketDirection.OUT, PacketType.STATS, "Stats socket connected to ${dest.name}")
                     while(isActive) {
                         val frame = withTimeoutOrNull(STATS_TIMEOUT) { incoming.receive() }
                         if (frame is Frame.Text) {
@@ -1691,6 +1726,8 @@ class AudioCastService : Service() {
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
+                Log.e(TAG, "Stats WS connection to ${dest.host}:${dest.port} failed: ${e.message}", e)
+                PacketLogger.log(PacketDirection.IN, PacketType.STATS, "Stats connection to ${dest.name} failed: ${e.message ?: e.javaClass.simpleName}")
                 delay(RECONNECT_INITIAL_BACKOFF)
             }
         }

--- a/app/src/main/java/com/aria/ariacast/MainActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.aria.ariacast
 
+import android.Manifest
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
 import android.app.Activity
@@ -8,9 +9,11 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.media.projection.MediaProjectionManager
+import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.provider.Settings
@@ -147,6 +150,32 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private val requestCastPermissions = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { grants ->
+        val recordAudioGranted = grants[Manifest.permission.RECORD_AUDIO]
+            ?: (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED)
+        if (recordAudioGranted) {
+            startMediaProjection.launch(mediaProjectionManager.createScreenCaptureIntent())
+        } else {
+            Toast.makeText(this, getString(R.string.record_audio_permission_required), Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun beginCast() {
+        val permissionsNeeded = mutableListOf<String>()
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+            permissionsNeeded.add(Manifest.permission.RECORD_AUDIO)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            permissionsNeeded.add(Manifest.permission.POST_NOTIFICATIONS)
+        }
+        if (permissionsNeeded.isNotEmpty()) {
+            requestCastPermissions.launch(permissionsNeeded.toTypedArray())
+        } else {
+            startMediaProjection.launch(mediaProjectionManager.createScreenCaptureIntent())
+        }
+    }
+
     fun castToServers(servers: List<Server>) {
         selectedServers = servers
         val companionEnabled = sharedPreferences.getBoolean(AriaCompanionActivity.KEY_COMPANION_ENABLED, false)
@@ -154,7 +183,7 @@ class MainActivity : AppCompatActivity() {
         if (companionEnabled && !companionIp.isNullOrEmpty()) {
             launchCompanionCast()
         } else {
-            startMediaProjection.launch(mediaProjectionManager.createScreenCaptureIntent())
+            beginCast()
         }
     }
 
@@ -263,7 +292,7 @@ class MainActivity : AppCompatActivity() {
                 startService(serviceIntent)
             } else {
                 if (selectedServers.isNotEmpty()) {
-                    startMediaProjection.launch(mediaProjectionManager.createScreenCaptureIntent())
+                    beginCast()
                 } else {
                     Toast.makeText(this, getString(R.string.select_server_first), Toast.LENGTH_SHORT).show()
                 }

--- a/app/src/main/java/com/aria/ariacast/MainActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/MainActivity.kt
@@ -16,7 +16,6 @@ import android.media.projection.MediaProjectionManager
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
-import android.provider.Settings
 import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.Menu
@@ -575,17 +574,6 @@ class MainActivity : AppCompatActivity() {
         } else {
             permissionButton.visibility = View.GONE
         }
-    }
-
-    private fun showNotificationAccessExplanationDialog() {
-        MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.notification_access_required_title)
-            .setMessage(R.string.notification_access_required_message)
-            .setPositiveButton(R.string.open_notification_settings) { _, _ ->
-                startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
-            }
-            .setNegativeButton(R.string.cancel, null)
-            .show()
     }
 
     private fun showPairingPinDialog(host: String) {

--- a/app/src/main/java/com/aria/ariacast/MainActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/MainActivity.kt
@@ -312,8 +312,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         permissionButton.setOnClickListener {
-            val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
-            startActivity(intent)
+            showNotificationAccessExplanationDialog()
         }
 
         lifecycleScope.launch {
@@ -576,6 +575,17 @@ class MainActivity : AppCompatActivity() {
         } else {
             permissionButton.visibility = View.GONE
         }
+    }
+
+    private fun showNotificationAccessExplanationDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.notification_access_required_title)
+            .setMessage(R.string.notification_access_required_message)
+            .setPositiveButton(R.string.open_notification_settings) { _, _ ->
+                startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
     }
 
     private fun showPairingPinDialog(host: String) {

--- a/app/src/main/java/com/aria/ariacast/NotificationAccessDialog.kt
+++ b/app/src/main/java/com/aria/ariacast/NotificationAccessDialog.kt
@@ -1,0 +1,17 @@
+package com.aria.ariacast
+
+import android.app.Activity
+import android.content.Intent
+import android.provider.Settings
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+fun Activity.showNotificationAccessExplanationDialog() {
+    MaterialAlertDialogBuilder(this)
+        .setTitle(R.string.notification_access_required_title)
+        .setMessage(R.string.notification_access_required_message)
+        .setPositiveButton(R.string.open_notification_settings) { _, _ ->
+            startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+        }
+        .setNegativeButton(R.string.cancel, null)
+        .show()
+}

--- a/app/src/main/java/com/aria/ariacast/PacketLogger.kt
+++ b/app/src/main/java/com/aria/ariacast/PacketLogger.kt
@@ -25,10 +25,15 @@ object PacketLogger {
     private val _logFlow = MutableSharedFlow<PacketLog>(extraBufferCapacity = 100)
     val logFlow = _logFlow.asSharedFlow()
 
-    private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
+    // SimpleDateFormat is not thread-safe; log() is called concurrently from multiple
+    // Dispatchers.IO threads (one audio/control/stats session per cast destination),
+    // so each thread needs its own formatter instance rather than sharing one.
+    private val dateFormat = object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue(): SimpleDateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
+    }
 
     fun log(direction: PacketDirection, type: PacketType, message: String, payloadSize: Int = 0) {
-        val timestamp = dateFormat.format(Date())
+        val timestamp = dateFormat.get()!!.format(Date())
         val entry = PacketLog(
             timestamp = timestamp,
             direction = direction,

--- a/app/src/main/java/com/aria/ariacast/SettingsActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/SettingsActivity.kt
@@ -102,8 +102,7 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         findViewById<View>(R.id.notificationAccessLayout).setOnClickListener {
-            val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
-            startActivity(intent)
+            showNotificationAccessExplanationDialog()
         }
 
         findViewById<View>(R.id.updateLayout).setOnClickListener {
@@ -303,6 +302,17 @@ class SettingsActivity : AppCompatActivity() {
             "zh" -> "简体中文"
             else -> getString(R.string.language_default)
         }
+    }
+
+    private fun showNotificationAccessExplanationDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.notification_access_required_title)
+            .setMessage(R.string.notification_access_required_message)
+            .setPositiveButton(R.string.open_notification_settings) { _, _ ->
+                startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
     }
 
     private fun handlePacketLogClick() {

--- a/app/src/main/java/com/aria/ariacast/SettingsActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/SettingsActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.res.ColorStateList
 import android.net.Uri
 import android.os.Bundle
-import android.provider.Settings
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -302,17 +301,6 @@ class SettingsActivity : AppCompatActivity() {
             "zh" -> "简体中文"
             else -> getString(R.string.language_default)
         }
-    }
-
-    private fun showNotificationAccessExplanationDialog() {
-        MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.notification_access_required_title)
-            .setMessage(R.string.notification_access_required_message)
-            .setPositiveButton(R.string.open_notification_settings) { _, _ ->
-                startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
-            }
-            .setNegativeButton(R.string.cancel, null)
-            .show()
     }
 
     private fun handlePacketLogClick() {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,6 +13,9 @@
     <!-- Main Activity -->
     <string name="media_projection_denied">Autorisation MediaProjection refusée.</string>
     <string name="record_audio_permission_required">L\'autorisation Microphone est requise pour capturer et diffuser l\'audio.</string>
+    <string name="notification_access_required_title">Accès aux notifications requis</string>
+    <string name="notification_access_required_message">Ce n\'est pas seulement pour afficher les infos de piste : certains récepteurs (comme le plugin AriaCast Receiver de Music Assistant) ne démarrent la lecture que lorsqu\'AriaCast leur indique que la lecture a commencé, et ce signal passe par l\'accès aux notifications. Sans lui, le cast peut sembler connecté et l\'audio peut être envoyé, mais rien ne sera réellement joué.\n\nSi Android affiche « Ce paramètre est actuellement indisponible » ou « Paramètre restreint », allez dans Paramètres → Applications → AriaCast, appuyez sur le menu ⋮ en haut à droite, puis choisissez « Autoriser les paramètres restreints » — requis pour les applications installées hors du Play Store. Réessayez ensuite d\'activer l\'accès.</string>
+    <string name="open_notification_settings">Ouvrir les réglages</string>
     <string name="select_server_first">Veuillez d\'abord sélectionner un serveur.</string>
     <string name="scanning">Analyse…</string>
     <string name="refresh">Actualiser</string>
@@ -72,7 +75,7 @@
     <string name="plugins">Plugins</string>
     <string name="manage_plugins_desc">Gérer les extensions basées sur des scripts</string>
     <string name="notification_access">Accès aux notifications</string>
-    <string name="notification_access_desc">Requis pour les métadonnées multimédias</string>
+    <string name="notification_access_desc">Requis pour les métadonnées multimédias ET pour démarrer la lecture sur certains récepteurs</string>
     <string name="check_for_updates">Vérifier les mises à jour</string>
     <string name="github_repo">Dépôt GitHub</string>
     <string name="github_repo_desc">Voir le code source et signaler des problèmes</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -12,6 +12,7 @@
 
     <!-- Main Activity -->
     <string name="media_projection_denied">Autorisation MediaProjection refusée.</string>
+    <string name="record_audio_permission_required">L\'autorisation Microphone est requise pour capturer et diffuser l\'audio.</string>
     <string name="select_server_first">Veuillez d\'abord sélectionner un serveur.</string>
     <string name="scanning">Analyse…</string>
     <string name="refresh">Actualiser</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
 
     <!-- Main Activity -->
     <string name="media_projection_denied">MediaProjection permission denied.</string>
+    <string name="record_audio_permission_required">Microphone permission is required to capture and cast audio.</string>
     <string name="select_server_first">Please select a server first.</string>
     <string name="scanning">Scanning…</string>
     <string name="refresh">Refresh</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,9 @@
     <!-- Main Activity -->
     <string name="media_projection_denied">MediaProjection permission denied.</string>
     <string name="record_audio_permission_required">Microphone permission is required to capture and cast audio.</string>
+    <string name="notification_access_required_title">Notification Access Required</string>
+    <string name="notification_access_required_message">This isn\'t just for showing track info: some receivers (like the Music Assistant AriaCast Receiver) only start playback once AriaCast tells them playback has started, and that signal is sent through Notification Access. Without it, casting can look connected and audio can be sent, but nothing will actually play.\n\nIf Android shows \"This setting is currently unavailable\" or \"Restricted setting\", go to Settings → Apps → AriaCast, tap the ⋮ menu in the top right, and choose \"Allow restricted settings\" — this is required for apps installed outside the Play Store. Then try enabling it again.</string>
+    <string name="open_notification_settings">Open Settings</string>
     <string name="select_server_first">Please select a server first.</string>
     <string name="scanning">Scanning…</string>
     <string name="refresh">Refresh</string>
@@ -77,7 +80,7 @@
     <string name="plugins">Plugins</string>
     <string name="manage_plugins_desc">Manage script-based extensions</string>
     <string name="notification_access">Notification Access</string>
-    <string name="notification_access_desc">Required for media metadata</string>
+    <string name="notification_access_desc">Required for media metadata AND to start playback on some receivers</string>
     <string name="check_for_updates">Check for Updates</string>
     <string name="github_repo">GitHub Repository</string>
     <string name="github_repo_desc">View source code and report issues</string>

--- a/app/src/test/java/com/aria/ariacast/PacketLoggerTest.kt
+++ b/app/src/test/java/com/aria/ariacast/PacketLoggerTest.kt
@@ -1,0 +1,84 @@
+package com.aria.ariacast
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * AudioCastService launches a separate control/audio/stats coroutine per cast
+ * destination (all on Dispatchers.IO), and every one of them calls
+ * PacketLogger.log() on its own thread. This test reproduces that concurrency
+ * to guard against regressions like a shared non-thread-safe SimpleDateFormat.
+ */
+class PacketLoggerTest {
+
+    @Before
+    fun setUp() {
+        PacketLogger.clear()
+    }
+
+    @Test
+    fun `log() survives concurrent calls from many threads without throwing or corrupting timestamps`() {
+        val threadCount = 16
+        val logsPerThread = 500
+        val timestampPattern = Regex("^\\d{2}:\\d{2}:\\d{2}\\.\\d{3}$")
+
+        val errors = CopyOnWriteArrayList<Throwable>()
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+
+        repeat(threadCount) { threadIndex ->
+            executor.submit {
+                try {
+                    startLatch.await()
+                    repeat(logsPerThread) { i ->
+                        // Unique message per call so entries aren't coalesced by the
+                        // repeat-collapsing logic, keeping the formatter under load.
+                        PacketLogger.log(
+                            direction = if (i % 2 == 0) PacketDirection.IN else PacketDirection.OUT,
+                            type = PacketType.AUDIO,
+                            message = "thread-$threadIndex-frame-$i"
+                        )
+                    }
+                } catch (t: Throwable) {
+                    errors.add(t)
+                } finally {
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        startLatch.countDown()
+        assertTrue("Threads did not finish in time", doneLatch.await(30, TimeUnit.SECONDS))
+        executor.shutdown()
+
+        assertTrue("PacketLogger.log() threw under concurrent access: $errors", errors.isEmpty())
+
+        val logs = PacketLogger.logs
+        assertTrue("Expected some logs to be recorded", logs.isNotEmpty())
+        assertTrue("Log buffer should be capped at 500 entries", logs.size <= 500)
+        logs.forEach { entry ->
+            assertTrue(
+                "Timestamp \"${entry.timestamp}\" is not well-formed (SimpleDateFormat corruption?)",
+                timestampPattern.matches(entry.timestamp)
+            )
+        }
+    }
+
+    @Test
+    fun `log() coalesces identical consecutive entries into a single entry with an incrementing count`() {
+        repeat(5) {
+            PacketLogger.log(PacketDirection.OUT, PacketType.AUDIO, "Audio frame sent")
+        }
+
+        val logs = PacketLogger.logs
+        assertEquals(1, logs.size)
+        assertEquals(5, logs[0].count)
+    }
+}


### PR DESCRIPTION
## Context

Debugging report: on Android 13, casting to a Music Assistant "AriaCast Receiver" shows "Casting..." in the UI, but no audio ever reaches the server and there are zero server-side logs.

Investigation found that the client-side WebSocket paths (`/audio`, `/control`, `/stats`) silently swallowed connection exceptions, `sendAudioFrame` only incremented a `droppedFrames` counter on failure, and the app's own diagnostic screen (`PacketLogActivity` / `PacketLogger`, unlocked via 3x long-press on "Reset last server" in Settings) was fully built but never fed any data — so there was no way to see what was actually happening on-device without adb.

## Changes

- `AudioCastService.kt`: wire `PacketLogger` into the audio capture loop (including a silence/signal detector on captured PCM frames) and into the `/audio`, `/control`, `/stats` WebSocket connect/fail paths, plus add `Log.e`/`Log.w` where exceptions were previously swallowed silently.
- `MainActivity.kt`: request `RECORD_AUDIO` and `POST_NOTIFICATIONS` explicitly at runtime before launching the MediaProjection consent screen. Both are declared in the manifest as dangerous/runtime permissions on API 31+/33+ but were never actually requested anywhere in the codebase — the app relied entirely on the MediaProjection dialog.
- `strings.xml` / `strings-fr.xml`: add `record_audio_permission_required` string.

## Test plan

- [ ] Build and install on an Android 13 device
- [ ] Grant Microphone/Notifications permission when prompted
- [ ] Attempt to cast to a Music Assistant AriaCast Receiver
- [ ] Open Settings → long-press "Reset last server" x3 → Packet Log, confirm it now shows connection attempts, capture start, and silence/signal transitions