### PR TITLE
fix(airplay1): connect to advertised port, fix socket reuse on fallback

### DIFF
--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -387,6 +387,7 @@ class AudioCastService : Service() {
             putString(KEY_LAST_SERVER_HOST, receiver.host)
             putInt(KEY_LAST_SERVER_PORT, receiver.port)
             putString(KEY_LAST_SERVER_NAME, receiver.name)
+            putString(KEY_LAST_SERVER_PLATFORM, receiver.platform)
             apply()
         }
 
@@ -554,6 +555,7 @@ class AudioCastService : Service() {
                 putString(KEY_LAST_SERVER_HOST, destinations[0].host)
                 putInt(KEY_LAST_SERVER_PORT, destinations[0].port)
                 putString(KEY_LAST_SERVER_NAME, destinations[0].name)
+                putString(KEY_LAST_SERVER_PLATFORM, destinations[0].platform)
                 apply()
             }
         }
@@ -1055,25 +1057,23 @@ class AudioCastService : Service() {
 
     private suspend fun performRaopHandshake(dest: CastDestination, myIp: String) = withContext(Dispatchers.IO) {
         try {
-            val targetPort = if (dest.port > 0) {
-                if (dest.port == 7000) 5000 else dest.port
-            } else 5000
-            
-            val socket = Socket()
-            try {
+            val advertisedPort = if (dest.port > 0) dest.port else 5000
+            val portsToTry = if (advertisedPort == 7000) listOf(7000, 5000) else listOf(advertisedPort)
+
+            var socket: Socket? = null
+            for (port in portsToTry) {
                 try {
-                    socket.connect(java.net.InetSocketAddress(dest.host, targetPort), 5000)
+                    val s = Socket()
+                    s.connect(java.net.InetSocketAddress(dest.host, port), 5000)
+                    socket = s
+                    break
                 } catch (e: Exception) {
-                    if (targetPort == 5000 && (dest.port == 7000 || dest.port == 0)) {
-                        socket.connect(java.net.InetSocketAddress(dest.host, 7000), 5000)
-                    } else throw e
+                    if (port == portsToTry.last()) throw e
+                    Log.d(TAG, "RAOP connect to ${dest.host}:$port failed, trying next port")
                 }
-            } catch (e: Exception) {
-                // Not registered in raopSockets yet, so cleanupSession/the outer catch below
-                // can't close this for us - close it here or the file descriptor leaks.
-                try { socket.close() } catch (ignored: Exception) {}
-                throw e
             }
+            socket!!
+            val targetPort = socket.port
 
             socket.soTimeout = 10000
             socket.tcpNoDelay = true
@@ -2134,6 +2134,7 @@ class AudioCastService : Service() {
         const val KEY_LAST_SERVER_HOST = "last_server_host"
         const val KEY_LAST_SERVER_PORT = "last_server_port"
         const val KEY_LAST_SERVER_NAME = "last_server_name"
+        const val KEY_LAST_SERVER_PLATFORM = "last_server_platform"
 
         const val SAMPLE_RATE = 48000
         const val FRAME_SIZE = 3840

--- a/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
+++ b/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
@@ -64,11 +64,17 @@ class DiscoveryManager(private val context: Context) {
 
         override fun onServiceLost(serviceInfo: NsdServiceInfo) {
             Log.d(TAG, "Service lost: ${serviceInfo.serviceName}")
-            val nameToRemove = if (serviceInfo.serviceType.contains("_raop") && serviceInfo.serviceName.contains("@")) {
+            val baseName = if (serviceInfo.serviceType.contains("_raop") && serviceInfo.serviceName.contains("@")) {
                 serviceInfo.serviceName.substringAfter("@")
             } else {
                 serviceInfo.serviceName
             }
+            val platform = when {
+                serviceInfo.serviceType.contains("_raop") -> "AirPlay"
+                serviceInfo.serviceType.contains("_airplay") -> "AirPlay2"
+                else -> null
+            }
+            val nameToRemove = if (platform != null) "$baseName::$platform" else baseName
             synchronized(discoveredServers) {
                 discoveredServers.remove(nameToRemove)
                 _servers.value = discoveredServers.values.toList()
@@ -206,7 +212,8 @@ class DiscoveryManager(private val context: Context) {
             // the display name so both stay visible rather than one clobbering the other.
             val existingSameName = discoveredServers[name]
             val spoofedName = existingSameName != null && existingSameName.host != hostAddress
-            val key = if (spoofedName) "$name@$hostAddress" else name
+            val baseKey = if (spoofedName) "$name@$hostAddress" else name
+            val key = if (platform == "AirPlay" || platform == "AirPlay2") "$baseKey::$platform" else baseKey
             val candidate = if (spoofedName) server.copy(name = "$name ($hostAddress)") else server
 
             val existing = discoveredServers[key]

--- a/app/src/main/java/com/aria/ariacast/MainActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/MainActivity.kt
@@ -529,13 +529,17 @@ class MainActivity : AppCompatActivity() {
                 val lastHost = sharedPreferences.getString(AudioCastService.KEY_LAST_SERVER_HOST, null)
                 
                 if (isUserSelecting && selectedServers.size == 1) {
-                    val found = displayedServers.find { it.host == selectedServers[0].host }
+                    val sel = selectedServers[0]
+                    val found = displayedServers.find { it.host == sel.host && it.platform == sel.platform }
+                        ?: displayedServers.find { it.host == sel.host }
                     if (found != null) {
                         selectedServers = listOf(found)
                         serverListAdapter.setSelectedItem(displayedServers.indexOf(found))
                     }
                 } else if (lastHost != null && selectedServers.isEmpty()) {
-                    val lastServer = displayedServers.find { it.host == lastHost }
+                    val lastPlatform = sharedPreferences.getString(AudioCastService.KEY_LAST_SERVER_PLATFORM, null)
+                    val lastServer = displayedServers.find { it.host == lastHost && (lastPlatform == null || it.platform == lastPlatform) }
+                        ?: displayedServers.find { it.host == lastHost }
                     if (lastServer != null) {
                         selectedServers = listOf(lastServer)
                         serverListAdapter.setSelectedItem(displayedServers.indexOf(lastServer))

--- a/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
+++ b/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
@@ -380,6 +380,7 @@ class AirPlay2Client(
         Log.d(TAG, "SETUP session response: code=${resp.code}, headers=${resp.headers}")
         if (resp.code != 200) { Log.e(TAG, "SETUP session failed: ${resp.code}"); return false }
         sessionId = resp.headers["Session"]?.substringBefore(";")?.trim()
+            ?: sessionUuid.toString().uppercase()
         Log.d(TAG, "SETUP session: sessionId=$sessionId")
         val transport = resp.headers["Transport"] ?: ""
         parseTransportResponse(transport)
@@ -408,10 +409,57 @@ class AirPlay2Client(
             streamConnectionId = sessionUuid.mostSignificantBits
         )
         val resp = sendRtspRequest("SETUP", sessionUrl, "application/x-apple-binary-plist", plist)
+        Log.d(TAG, "SETUP stream response: code=${resp.code}, headers=${resp.headers}, bodySize=${resp.body?.size}")
         if (resp.code != 200) return false
+
+        // AirPlay 2 returns port info in the response body plist, not the Transport header
         val transport = resp.headers["Transport"] ?: ""
         parseTransportResponse(transport)
+
+        resp.body?.let { body ->
+            try {
+                val dict = BinaryPlist.decode(body)
+                Log.d(TAG, "SETUP stream plist keys: ${dict.keys}")
+                // Ports may be top-level or inside a "streams" array
+                val dataPort = (dict["dataPort"] as? Long)?.toInt()
+                    ?: (dict["server_port"] as? Long)?.toInt()
+                val ctrlPort = (dict["controlPort"] as? Long)?.toInt()
+                val evtPort = (dict["eventPort"] as? Long)?.toInt()
+
+                // Also check inside streams array
+                val streams = dict["streams"]
+                if (streams is List<*> && streams.isNotEmpty()) {
+                    val stream = streams[0] as? Map<*, *>
+                    if (stream != null) {
+                        Log.d(TAG, "SETUP stream[0] keys: ${stream.keys}")
+                        val dp = (stream["dataPort"] as? Long)?.toInt()
+                            ?: (stream["server_port"] as? Long)?.toInt()
+                        val cp = (stream["controlPort"] as? Long)?.toInt()
+                        if (dp != null && dp > 0) audioRemotePort = dp
+                        if (cp != null && cp > 0) controlRemotePort = cp
+                    }
+                }
+
+                if (dataPort != null && dataPort > 0) audioRemotePort = dataPort
+                if (ctrlPort != null && ctrlPort > 0) controlRemotePort = ctrlPort
+                if (evtPort != null && evtPort > 0) eventPort = evtPort
+                Log.d(TAG, "SETUP stream parsed: audio=$audioRemotePort ctrl=$controlRemotePort event=$eventPort")
+            } catch (e: Exception) {
+                Log.w(TAG, "SETUP stream plist parse failed: ${e.message}")
+            }
+        }
+
         audioSocket = DatagramSocket(0)
+
+        // When transient pairing skipped pair-verify, cipherKeys is null but the
+        // server expects encrypted audio because we sent shk. Use shk as the
+        // encryption key (the server uses the same shk to decrypt).
+        if (cipherKeys == null) {
+            cipherKeys = AirPlay2Crypto.PairKeysResult(shk, shk, 0L, 0L)
+            supportsEncryption = true
+            Log.d(TAG, "Using stream shared key for audio encryption (transient pairing)")
+        }
+
         return true
     }
 

--- a/app/src/main/java/com/aria/ariacast/airplay2/BinaryPlist.kt
+++ b/app/src/main/java/com/aria/ariacast/airplay2/BinaryPlist.kt
@@ -167,14 +167,14 @@ object BinaryPlist {
         "deviceID" to "00:00:00:00:00:00",
         "sessionUUID" to uuid.toString().uppercase(),
         "timingPort" to 0L,
-        "timingProtocol" to "NTP"
+        "timingProtocol" to "PTP"
     ))
 
     fun makeSessionPlist(uuid: UUID, deviceId: String, timingPort: Int): ByteArray = encode(mapOf(
         "deviceID" to deviceId,
         "sessionUUID" to uuid.toString().uppercase(),
         "timingPort" to timingPort.toLong(),
-        "timingProtocol" to "NTP"
+        "timingProtocol" to "PTP"
     ))
 
     fun decode(data: ByteArray): Map<String, Any?> {


### PR DESCRIPTION
The RAOP handshake rewrote port 7000 to 5000, assuming AirPlay 2 receivers have a separate AirPlay 1 listener. They don't — shairport-sync accepts Classic AirPlay on 7000.

The fallback path also reused a failed socket, which throws on the second `connect()`. Create a fresh socket per attempt.

Depends on: #36