### PR TITLE
fix(airplay2): use PTP timing protocol instead of NTP

### DIFF
--- a/app/src/main/java/com/aria/ariacast/airplay2/BinaryPlist.kt
+++ b/app/src/main/java/com/aria/ariacast/airplay2/BinaryPlist.kt
@@ -167,14 +167,14 @@ object BinaryPlist {
         "deviceID" to "00:00:00:00:00:00",
         "sessionUUID" to uuid.toString().uppercase(),
         "timingPort" to 0L,
-        "timingProtocol" to "NTP"
+        "timingProtocol" to "PTP"
     ))
 
     fun makeSessionPlist(uuid: UUID, deviceId: String, timingPort: Int): ByteArray = encode(mapOf(
         "deviceID" to deviceId,
         "sessionUUID" to uuid.toString().uppercase(),
         "timingPort" to timingPort.toLong(),
-        "timingProtocol" to "NTP"
+        "timingProtocol" to "PTP"
     ))
 
     fun decode(data: ByteArray): Map<String, Any?> {


### PR DESCRIPTION
AirPlay 2 receivers (e.g. shairport-sync) use PTP (IEEE 1588) for clock synchronization, not NTP. The SETUP plist sent `timingProtocol: NTP` which shairport-sync rejects with:

```
SETUP on Connection: ntp stream handling is not implemented!
warning: Shairport Sync can not handle NTP streams.
```

Change both `encodeSet` and `makeSessionPlist` in BinaryPlist to send `timingProtocol: PTP`.

Tested against shairport-sync 5.0.4 in AirPlay 2 mode — the connection is now accepted as a PTP stream.