### PR TITLE
fix(resampler): normalize polyphase filter to unity gain

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Not required: NfcWriteActivity checks NfcAdapter.getDefaultAdapter() itself and
          shows an unavailable state, so the app stays installable on devices without NFC. -->
     <uses-feature android:name="android.hardware.nfc" android:required="false" />

--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -387,6 +387,7 @@ class AudioCastService : Service() {
             putString(KEY_LAST_SERVER_HOST, receiver.host)
             putInt(KEY_LAST_SERVER_PORT, receiver.port)
             putString(KEY_LAST_SERVER_NAME, receiver.name)
+            putString(KEY_LAST_SERVER_PLATFORM, receiver.platform)
             apply()
         }
 
@@ -554,6 +555,7 @@ class AudioCastService : Service() {
                 putString(KEY_LAST_SERVER_HOST, destinations[0].host)
                 putInt(KEY_LAST_SERVER_PORT, destinations[0].port)
                 putString(KEY_LAST_SERVER_NAME, destinations[0].name)
+                putString(KEY_LAST_SERVER_PLATFORM, destinations[0].platform)
                 apply()
             }
         }
@@ -1055,25 +1057,23 @@ class AudioCastService : Service() {
 
     private suspend fun performRaopHandshake(dest: CastDestination, myIp: String) = withContext(Dispatchers.IO) {
         try {
-            val targetPort = if (dest.port > 0) {
-                if (dest.port == 7000) 5000 else dest.port
-            } else 5000
-            
-            val socket = Socket()
-            try {
+            val advertisedPort = if (dest.port > 0) dest.port else 5000
+            val portsToTry = if (advertisedPort == 7000) listOf(7000, 5000) else listOf(advertisedPort)
+
+            var socket: Socket? = null
+            for (port in portsToTry) {
                 try {
-                    socket.connect(java.net.InetSocketAddress(dest.host, targetPort), 5000)
+                    val s = Socket()
+                    s.connect(java.net.InetSocketAddress(dest.host, port), 5000)
+                    socket = s
+                    break
                 } catch (e: Exception) {
-                    if (targetPort == 5000 && (dest.port == 7000 || dest.port == 0)) {
-                        socket.connect(java.net.InetSocketAddress(dest.host, 7000), 5000)
-                    } else throw e
+                    if (port == portsToTry.last()) throw e
+                    Log.d(TAG, "RAOP connect to ${dest.host}:$port failed, trying next port")
                 }
-            } catch (e: Exception) {
-                // Not registered in raopSockets yet, so cleanupSession/the outer catch below
-                // can't close this for us - close it here or the file descriptor leaks.
-                try { socket.close() } catch (ignored: Exception) {}
-                throw e
             }
+            socket!!
+            val targetPort = socket.port
 
             socket.soTimeout = 10000
             socket.tcpNoDelay = true
@@ -2134,6 +2134,7 @@ class AudioCastService : Service() {
         const val KEY_LAST_SERVER_HOST = "last_server_host"
         const val KEY_LAST_SERVER_PORT = "last_server_port"
         const val KEY_LAST_SERVER_NAME = "last_server_name"
+        const val KEY_LAST_SERVER_PLATFORM = "last_server_platform"
 
         const val SAMPLE_RATE = 48000
         const val FRAME_SIZE = 3840

--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -26,6 +26,7 @@ import android.media.projection.MediaProjectionManager
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 import android.util.DisplayMetrics
 import android.util.Log
 import android.view.WindowManager
@@ -98,6 +99,7 @@ class AudioCastService : Service() {
     private var audioRecord: AudioRecord? = null
     private var virtualDisplay: VirtualDisplay? = null
     private var videoCodec: MediaCodec? = null
+    private var wakeLock: PowerManager.WakeLock? = null
     
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var securePreferences: SharedPreferences
@@ -409,6 +411,8 @@ class AudioCastService : Service() {
             }
         }
 
+        acquireWakeLock()
+
         val companionIp = sharedPreferences.getString(AriaCompanionActivity.KEY_COMPANION_IP, null)
         val companionPort = sharedPreferences.getInt(AriaCompanionActivity.KEY_COMPANION_PORT, COMPANION_API_PORT)
 
@@ -578,6 +582,8 @@ class AudioCastService : Service() {
                 throw e
             }
         }
+
+        acquireWakeLock()
 
         // MediaProjection token is single-use on Android 14+; obtain it once before any retries.
         val projection = mediaProjectionManager.getMediaProjection(Activity.RESULT_OK, mediaProjectionToken)
@@ -1978,6 +1984,7 @@ class AudioCastService : Service() {
     private fun cleanupSession() {
         val destinations = _activeDestinations.value.toList()
         val teardownJobs = stopRemoteSessions(destinations)
+        releaseWakeLock()
 
         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, originalVolume, 0)
         
@@ -2034,6 +2041,25 @@ class AudioCastService : Service() {
         sessionJob = null
         _state.value = CastState.OFF
         _stats.value = CastingStats()
+    }
+
+    private fun acquireWakeLock() {
+        if (wakeLock == null) {
+            val pm = getSystemService(POWER_SERVICE) as PowerManager
+            wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "AriaCast::Casting")
+        }
+        wakeLock?.acquire()
+        Log.d(TAG, "Wake lock acquired")
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.let {
+            if (it.isHeld) {
+                it.release()
+                Log.d(TAG, "Wake lock released")
+            }
+        }
+        wakeLock = null
     }
 
     private fun stopRemoteSessions(destinations: List<CastDestination>): List<Job> {

--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -64,6 +64,8 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
+import java.net.DatagramPacket
+import java.net.DatagramSocket
 import java.net.InetAddress
 import java.net.NetworkInterface
 import java.net.ServerSocket
@@ -1056,6 +1058,11 @@ class AudioCastService : Service() {
     }
 
     private suspend fun performRaopHandshake(dest: CastDestination, myIp: String) = withContext(Dispatchers.IO) {
+        // UDP sockets for audio, control, and timing
+        val audioUdp = DatagramSocket(0)
+        val controlUdp = DatagramSocket(0)
+        val timingUdp = DatagramSocket(0)
+
         try {
             val advertisedPort = if (dest.port > 0) dest.port else 5000
             val portsToTry = if (advertisedPort == 7000) listOf(7000, 5000) else listOf(advertisedPort)
@@ -1078,7 +1085,7 @@ class AudioCastService : Service() {
             socket.soTimeout = 10000
             socket.tcpNoDelay = true
             raopSockets[dest.host] = socket
-            
+
             val input = socket.getInputStream()
             val output = socket.getOutputStream()
             var cseq = 0
@@ -1086,14 +1093,8 @@ class AudioCastService : Service() {
 
             val userAgent = "AirPlay/550.10"
             val sessionGuid = UUID.randomUUID().toString()
-            val rtpSessionId = (10000000..99999999).random() // Unique SSRC/Session ID for RTP
+            val rtpSessionId = (10000000..99999999).random()
 
-            // Some AirPlay 1 receivers (et bit 0 set in their mDNS TXT record - RaopDiscovery
-            // already only surfaces devices where this holds or et=0) refuse to play unless
-            // the stream is RSA/AES-CBC encrypted; most third-party RAOP receivers don't
-            // require it. Only add encryption when the receiver itself asked for it, so
-            // every receiver that already works unencrypted keeps working unchanged. et can
-            // be a bitmask (e.g. RSA + FairPlay together) - check the bit, not exact equality.
             val encryptionTypeBits = ExtraFields.get(dest.extra, "et")?.toIntOrNull() ?: 0
             val wantsEncryption = (encryptionTypeBits and 1) != 0
             var raopCrypto: RaopCrypto? = null
@@ -1119,8 +1120,8 @@ class AudioCastService : Service() {
                     "c=IN IP4 ${dest.host}\r\n" +
                     "t=0 0\r\n" +
                     "m=audio 0 RTP/AVP 96\r\n" +
-                    "a=rtpmap:96 L16/44100/2\r\n" +
-                    "a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100\r\n" +
+                    "a=rtpmap:96 L16/48000/2\r\n" +
+                    "a=fmtp:96 352 0 16 40 10 14 2 255 0 0 48000\r\n" +
                     cryptoSdp +
                     "a=control:rtp\r\n"
 
@@ -1140,13 +1141,27 @@ class AudioCastService : Service() {
             ), sdp)
             readRtspResponse(input)
 
-            // 2. SETUP
+            // 2. SETUP — advertise our UDP ports
             sendRtspRequest(output, "SETUP", dest.host, targetPort, cseq++, commonHeaders + mapOf(
-                "Transport" to "RTP/AVP/TCP;unicast;interleaved=0-1;mode=record"
+                "Transport" to "RTP/AVP/UDP;unicast;interleaved=0-1;mode=record;control_port=${controlUdp.localPort};timing_port=${timingUdp.localPort}"
             ))
             val setupResp = readRtspResponse(input)
             val session = setupResp.find { it.startsWith("Session:", true) }?.substringAfter(":")?.substringBefore(";")?.trim()
             raopSessions[dest.host] = session
+
+            // Parse server's UDP ports from SETUP response Transport header
+            var serverAudioPort = 0
+            var serverControlPort = 0
+            var serverTimingPort = 0
+            val transportHeader = setupResp.find { it.startsWith("Transport:", true) }?.substringAfter(":") ?: ""
+            transportHeader.split(";").forEach { part ->
+                when {
+                    part.trim().startsWith("server_port=") -> serverAudioPort = part.substringAfter("=").toIntOrNull() ?: 0
+                    part.trim().startsWith("control_port=") -> serverControlPort = part.substringAfter("=").toIntOrNull() ?: 0
+                    part.trim().startsWith("timing_port=") -> serverTimingPort = part.substringAfter("=").toIntOrNull() ?: 0
+                }
+            }
+            Log.d(TAG, "RAOP SETUP: server audio=$serverAudioPort control=$serverControlPort timing=$serverTimingPort")
 
             // 3. RECORD
             sendRtspRequest(output, "RECORD", dest.host, targetPort, cseq++, commonHeaders + mapOf(
@@ -1155,7 +1170,16 @@ class AudioCastService : Service() {
                 "RTP-Info" to "seq=0;rtptime=$LATENCY"
             ))
             readRtspResponse(input)
-            
+
+            // 4. Set initial volume to 0 dB (full) — AirPlay range is -30 (silent) to 0 (max)
+            val volBody = "volume: 0.000000\r\n"
+            sendRtspRequest(output, "SET_PARAMETER", dest.host, targetPort, cseq++, commonHeaders + mapOf(
+                "Session" to (session ?: ""),
+                "Content-Type" to "text/parameters",
+                "Content-Length" to volBody.length.toString()
+            ), volBody)
+            readRtspResponse(input)
+
             raopCSeqs[dest.host] = cseq
 
             _state.value = CastState.CASTING
@@ -1166,153 +1190,140 @@ class AudioCastService : Service() {
 
             var sequence = 0
             var timestamp = LATENCY
-            
-            // Interleaved receiver loop (Timing replies)
-            val receiverJob = launch {
+            val serverAddr = InetAddress.getByName(dest.host)
+            // Anchor: wall-clock time when timestamp == LATENCY
+            val startTimeMs = System.currentTimeMillis()
+            val startTimestamp = LATENCY
+
+            // UDP timing thread — receives timing requests from server and replies
+            // In Classic AirPlay, the SERVER sends timing requests to the CLIENT
+            val timingJob = launch(Dispatchers.IO) {
                 try {
+                    timingUdp.soTimeout = 5000 // 5s timeout for debugging
+                    val buf = ByteArray(256)
+                    Log.d(TAG, "RAOP timing thread started, listening on port ${timingUdp.localPort}")
                     while (isActive) {
-                        val dollar = input.read()
-                        if (dollar == -1) break
-                        if (dollar == 0x24) { // '$'
-                            val channel = input.read()
-                            val length = (input.read() shl 8) or input.read()
-                            val data = ByteArray(length)
-                            var read = 0
-                            while (read < length) {
-                                val r = input.read(data, read, length - read)
-                                if (r == -1) break
-                                read += r
-                            }
-                            
-                            // Check for Timing request (0x53) on Channel 1 (RTCP)
-                            if (channel == 1 && data.size >= 32) {
-                                val type = data[1].toInt() and 0x7F
-                                if (type == 0x53) {
-                                    // Extract sendtime (T1) from the end of request (offset 24-31)
+                        try {
+                            val pkt = DatagramPacket(buf, buf.size)
+                            timingUdp.receive(pkt)
+                            val data = pkt.data
+                            Log.d(TAG, "RAOP timing: received ${pkt.length} bytes from ${pkt.address}:${pkt.port}, type=0x${String.format("%02X", data[1])}")
+
+                            if (pkt.length >= 32) {
+                                val payloadType = data[1].toInt() and 0x7F
+                                if (payloadType == 0x52) { // Timing request (PT=82)
                                     val reqSendSec = ByteBuffer.wrap(data, 24, 4).int
                                     val reqSendFrac = ByteBuffer.wrap(data, 28, 4).int
-                                    
+
                                     val now = System.currentTimeMillis()
                                     val ntpSec = (now / 1000) + 0x83AA7E80
                                     val ntpFrac = ((now % 1000) * 0x100000000L / 1000).toInt()
-                                    
+
                                     val reply = ByteBuffer.allocate(32).apply {
                                         put(0x80.toByte())
-                                        put(0xD3.toByte()) // Timing reply
+                                        put(0xD3.toByte()) // Timing reply (PT=83 | marker)
                                         putShort(7.toShort())
                                         putInt(0) // padding
-                                        putInt(reqSendSec) // reftime (T1)
+                                        putInt(reqSendSec) // reference time (T1 from request)
                                         putInt(reqSendFrac)
-                                        putInt(ntpSec.toInt()) // recvtime (T2)
+                                        putInt(ntpSec.toInt()) // receive time (T2)
                                         putInt(ntpFrac)
-                                        putInt(ntpSec.toInt()) // sendtime (T3)
+                                        putInt(ntpSec.toInt()) // send time (T3)
                                         putInt(ntpFrac)
                                     }.array()
-                                    
-                                    synchronized(output) {
-                                        output.write(0x24)
-                                        output.write(0x01)
-                                        output.write((reply.size shr 8) and 0xFF)
-                                        output.write(reply.size and 0xFF)
-                                        output.write(reply)
-                                        output.flush()
-                                    }
+
+                                    val replyPkt = DatagramPacket(reply, reply.size, pkt.address, pkt.port)
+                                    timingUdp.send(replyPkt)
+                                    Log.d(TAG, "RAOP timing: sent reply to ${pkt.address}:${pkt.port}")
                                 }
                             }
+                        } catch (e: java.net.SocketTimeoutException) {
+                            Log.d(TAG, "RAOP timing: no packet received in 5s (port ${timingUdp.localPort})")
                         }
                     }
                 } catch (e: Exception) {
-                    Log.d(TAG, "RAOP receiver loop ended: ${e.message}")
+                    if (isActive) Log.d(TAG, "RAOP timing thread ended: ${e.message}")
                 }
             }
 
-            // Sync task
-            val syncJob = launch {
-                var isFirstSync = true
-                while (isActive) {
-                    val now = System.currentTimeMillis()
-                    val ntpSec = (now / 1000) + 0x83AA7E80
-                    val ntpFrac = ((now % 1000) * 0x100000000L / 1000).toInt()
-                    
-                    val syncPacket = ByteBuffer.allocate(20).apply {
-                        put((if (isFirstSync) 0x90 else 0x80).toByte())
-                        put(0xD4.toByte()) // Sync
-                        putShort(7.toShort())
-                        putInt(timestamp - LATENCY) // now_without_latency
-                        putInt(ntpSec.toInt())
-                        putInt(ntpFrac)
-                        putInt(timestamp) // now
-                    }.array()
-                    
-                    try {
-                        synchronized(output) {
-                            output.write(0x24) // '$'
-                            output.write(0x01) // channel 1
-                            output.write((syncPacket.size shr 8) and 0xFF)
-                            output.write(syncPacket.size and 0xFF)
-                            output.write(syncPacket)
-                            output.flush()
-                        }
-                    } catch (e: Exception) { break }
-                    isFirstSync = false
-                    delay(1000)
-                }
+            // UDP sync thread — send initial sync packet, then let receiver free-run
+            // from NTP timing exchange. Repeated sync packets fight the receiver's
+            // anchor correction and cause packet drops.
+            val syncJob = launch(Dispatchers.IO) {
+                // Wait briefly for the first timing exchange to complete
+                delay(500)
+
+                val nowMs = System.currentTimeMillis()
+                val ntpSec = (nowMs / 1000) + 0x83AA7E80
+                val ntpFrac = ((nowMs % 1000) * 0x100000000L / 1000).toInt()
+                val elapsedMs = nowMs - startTimeMs
+                val rtpNow = startTimestamp + (elapsedMs * 48000 / 1000).toInt()
+
+                val syncPacket = ByteBuffer.allocate(20).apply {
+                    put(0x90.toByte()) // first sync (extension bit set)
+                    put(0xD4.toByte())
+                    putShort(7.toShort())
+                    putInt(rtpNow - LATENCY)
+                    putInt(ntpSec.toInt())
+                    putInt(ntpFrac)
+                    putInt(rtpNow)
+                }.array()
+
+                try {
+                    val pkt = DatagramPacket(syncPacket, syncPacket.size, serverAddr, serverControlPort)
+                    controlUdp.send(pkt)
+                } catch (_: Exception) {}
+                // No more sync packets — receiver uses NTP timing exchange for clock correction
             }
 
+            // Audio send loop — send RTP packets over UDP with ALAC uncompressed framing
+            // Accumulate exactly 1408 bytes (352 stereo samples) per ALAC frame
+            val FRAME_BYTES = 1408 // 352 samples × 2 channels × 2 bytes
             try {
                 var isFirstPacket = true
                 val resampler = AudioResampler(channels = 2)
-                audioBufferFlow.collect { rawBuffer ->
-                    val buffer = resampler.resample(rawBuffer)
-                    for (offset in 0 until buffer.size step 1408) {
-                        val size = minOf(1408, buffer.size - offset)
-                        val chunk = buffer.copyOfRange(offset, offset + size)
+                val accumulator = ByteArrayOutputStream(FRAME_BYTES * 2)
 
-                        var bigEndianBuffer = ByteArray(chunk.size)
-                        for (i in 0 until chunk.size step 2) {
-                            if (i + 1 < chunk.size) {
-                                bigEndianBuffer[i] = chunk[i+1]
-                                bigEndianBuffer[i+1] = chunk[i]
-                            }
-                        }
-                        raopCrypto?.let { bigEndianBuffer = it.encryptAudio(bigEndianBuffer) }
+                audioBufferFlow.collect { rawBuffer ->
+                    val buffer = rawBuffer // skip resampler — capture and SDP both at 48000
+                    accumulator.write(buffer)
+
+                    val accBytes = accumulator.toByteArray()
+                    var consumed = 0
+                    while (consumed + FRAME_BYTES <= accBytes.size) {
+                        val chunk = accBytes.copyOfRange(consumed, consumed + FRAME_BYTES)
+                        consumed += FRAME_BYTES
+
+                        var alacFrame = alacEncodeUncompressedRaop(chunk)
+                        raopCrypto?.let { alacFrame = it.encryptAudio(alacFrame) }
 
                         val rtpHeader = ByteBuffer.allocate(12).apply {
                             put(0x80.toByte())
                             put((if (isFirstPacket) 0xE0 else 0x60).toByte())
                             putShort(sequence++.toShort())
                             putInt(timestamp)
-                            putInt(rtpSessionId) // SSRC MUST match SDP o= line
+                            putInt(rtpSessionId)
                         }
-                        timestamp += chunk.size / 4
+                        timestamp += FRAME_BYTES / 4 // 352 samples
                         isFirstPacket = false
 
-                        val payload = rtpHeader.array() + bigEndianBuffer
-                        
-                        try {
-                            synchronized(output) {
-                                output.write(0x24) // '$'
-                                output.write(0x00) // channel 0
-                                output.write((payload.size shr 8) and 0xFF)
-                                output.write(payload.size and 0xFF)
-                                output.write(payload)
-                                output.flush()
-                            }
-                        } catch (e: Exception) {
-                            throw CancellationException("RAOP stream closed")
-                        }
+                        val payload = rtpHeader.array() + alacFrame
+                        val pkt = DatagramPacket(payload, payload.size, serverAddr, serverAudioPort)
+                        audioUdp.send(pkt)
+                    }
+
+                    // Keep unconsumed remainder for next round
+                    accumulator.reset()
+                    if (consumed < accBytes.size) {
+                        accumulator.write(accBytes, consumed, accBytes.size - consumed)
                     }
                 }
             } finally {
                 syncJob.cancel()
-                receiverJob.cancel()
+                timingJob.cancel()
             }
         } catch (e: Exception) {
             Log.e(TAG, "RAOP failed for ${dest.host}: ${e.message}")
-            // This catches CancellationException too (e.g. the user hit Stop), where an
-            // ordinary suspend call would immediately throw - NonCancellable lets a TEARDOWN
-            // actually reach the receiver here, in-line, instead of racing the separate
-            // async send in stopRemoteSessions() against this coroutine's own socket close.
             withContext(NonCancellable) {
                 try {
                     val socket = raopSockets[dest.host]
@@ -1328,6 +1339,10 @@ class AudioCastService : Service() {
             raopSockets.remove(dest.host)?.close()
             raopSessions.remove(dest.host)
             raopCSeqs.remove(dest.host)
+        } finally {
+            audioUdp.close()
+            controlUdp.close()
+            timingUdp.close()
         }
     }
 
@@ -2157,4 +2172,46 @@ class AudioCastService : Service() {
         private const val ARTWORK_PORT = 8090
         private const val STREAM_PORT = 8091
     }
+    /** Encode little-endian PCM into an ALAC uncompressed frame.
+     *  Writes the 23-bit ALAC header, byte-swaps each stereo sample pair
+     *  to big-endian, and appends the 3-bit end tag. */
+    private fun alacEncodeUncompressedRaop(pcm: ByteArray): ByteArray {
+        val out = ByteArray(3 + pcm.size + 1) // header + samples + trailer padding
+        var p = 0
+        var bpos = 0
+
+        fun writeBits(v: Int, blen: Int) {
+            val lb = 8 - bpos
+            val rb = lb - blen
+            if (rb >= 0) {
+                val bd = (v shl rb) and 0xFF
+                out[p] = if (bpos == 0) bd.toByte() else (out[p].toInt() or bd).toByte()
+                if (rb == 0) { p++; bpos = 0 } else bpos += blen
+            } else {
+                out[p] = (out[p].toInt() or ((v ushr (-rb)) and 0xFF)).toByte()
+                p++
+                out[p] = ((v shl (8 + rb)) and 0xFF).toByte()
+                bpos = -rb
+            }
+        }
+
+        // ALAC uncompressed frame header: 3 bits tag(1) + 4 bits unused + 8 bits unused
+        //                                 + 4 bits unused + 1 bit "has size" + 2 bits unused + 1 bit "not compressed"
+        writeBits(1, 3); writeBits(0, 4); writeBits(0, 8)
+        writeBits(0, 4); writeBits(0, 1); writeBits(0, 2); writeBits(1, 1)
+
+        // Byte-swap little-endian stereo samples to big-endian
+        var i = 0
+        while (i < pcm.size) {
+            writeBits(pcm[i + 1].toInt() and 0xFF, 8)  // L high
+            writeBits(pcm[i + 0].toInt() and 0xFF, 8)  // L low
+            writeBits(pcm[i + 3].toInt() and 0xFF, 8)  // R high
+            writeBits(pcm[i + 2].toInt() and 0xFF, 8)  // R low
+            i += 4
+        }
+        // End tag
+        writeBits(7, 3)
+        return out
+    }
+
 }

--- a/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
+++ b/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
@@ -64,11 +64,17 @@ class DiscoveryManager(private val context: Context) {
 
         override fun onServiceLost(serviceInfo: NsdServiceInfo) {
             Log.d(TAG, "Service lost: ${serviceInfo.serviceName}")
-            val nameToRemove = if (serviceInfo.serviceType.contains("_raop") && serviceInfo.serviceName.contains("@")) {
+            val baseName = if (serviceInfo.serviceType.contains("_raop") && serviceInfo.serviceName.contains("@")) {
                 serviceInfo.serviceName.substringAfter("@")
             } else {
                 serviceInfo.serviceName
             }
+            val platform = when {
+                serviceInfo.serviceType.contains("_raop") -> "AirPlay"
+                serviceInfo.serviceType.contains("_airplay") -> "AirPlay2"
+                else -> null
+            }
+            val nameToRemove = if (platform != null) "$baseName::$platform" else baseName
             synchronized(discoveredServers) {
                 discoveredServers.remove(nameToRemove)
                 _servers.value = discoveredServers.values.toList()
@@ -206,7 +212,8 @@ class DiscoveryManager(private val context: Context) {
             // the display name so both stay visible rather than one clobbering the other.
             val existingSameName = discoveredServers[name]
             val spoofedName = existingSameName != null && existingSameName.host != hostAddress
-            val key = if (spoofedName) "$name@$hostAddress" else name
+            val baseKey = if (spoofedName) "$name@$hostAddress" else name
+            val key = if (platform == "AirPlay" || platform == "AirPlay2") "$baseKey::$platform" else baseKey
             val candidate = if (spoofedName) server.copy(name = "$name ($hostAddress)") else server
 
             val existing = discoveredServers[key]

--- a/app/src/main/java/com/aria/ariacast/MainActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/MainActivity.kt
@@ -529,13 +529,17 @@ class MainActivity : AppCompatActivity() {
                 val lastHost = sharedPreferences.getString(AudioCastService.KEY_LAST_SERVER_HOST, null)
                 
                 if (isUserSelecting && selectedServers.size == 1) {
-                    val found = displayedServers.find { it.host == selectedServers[0].host }
+                    val sel = selectedServers[0]
+                    val found = displayedServers.find { it.host == sel.host && it.platform == sel.platform }
+                        ?: displayedServers.find { it.host == sel.host }
                     if (found != null) {
                         selectedServers = listOf(found)
                         serverListAdapter.setSelectedItem(displayedServers.indexOf(found))
                     }
                 } else if (lastHost != null && selectedServers.isEmpty()) {
-                    val lastServer = displayedServers.find { it.host == lastHost }
+                    val lastPlatform = sharedPreferences.getString(AudioCastService.KEY_LAST_SERVER_PLATFORM, null)
+                    val lastServer = displayedServers.find { it.host == lastHost && (lastPlatform == null || it.platform == lastPlatform) }
+                        ?: displayedServers.find { it.host == lastHost }
                     if (lastServer != null) {
                         selectedServers = listOf(lastServer)
                         serverListAdapter.setSelectedItem(displayedServers.indexOf(lastServer))

--- a/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
+++ b/app/src/main/java/com/aria/ariacast/airplay2/AirPlay2Client.kt
@@ -380,6 +380,7 @@ class AirPlay2Client(
         Log.d(TAG, "SETUP session response: code=${resp.code}, headers=${resp.headers}")
         if (resp.code != 200) { Log.e(TAG, "SETUP session failed: ${resp.code}"); return false }
         sessionId = resp.headers["Session"]?.substringBefore(";")?.trim()
+            ?: sessionUuid.toString().uppercase()
         Log.d(TAG, "SETUP session: sessionId=$sessionId")
         val transport = resp.headers["Transport"] ?: ""
         parseTransportResponse(transport)
@@ -408,10 +409,57 @@ class AirPlay2Client(
             streamConnectionId = sessionUuid.mostSignificantBits
         )
         val resp = sendRtspRequest("SETUP", sessionUrl, "application/x-apple-binary-plist", plist)
+        Log.d(TAG, "SETUP stream response: code=${resp.code}, headers=${resp.headers}, bodySize=${resp.body?.size}")
         if (resp.code != 200) return false
+
+        // AirPlay 2 returns port info in the response body plist, not the Transport header
         val transport = resp.headers["Transport"] ?: ""
         parseTransportResponse(transport)
+
+        resp.body?.let { body ->
+            try {
+                val dict = BinaryPlist.decode(body)
+                Log.d(TAG, "SETUP stream plist keys: ${dict.keys}")
+                // Ports may be top-level or inside a "streams" array
+                val dataPort = (dict["dataPort"] as? Long)?.toInt()
+                    ?: (dict["server_port"] as? Long)?.toInt()
+                val ctrlPort = (dict["controlPort"] as? Long)?.toInt()
+                val evtPort = (dict["eventPort"] as? Long)?.toInt()
+
+                // Also check inside streams array
+                val streams = dict["streams"]
+                if (streams is List<*> && streams.isNotEmpty()) {
+                    val stream = streams[0] as? Map<*, *>
+                    if (stream != null) {
+                        Log.d(TAG, "SETUP stream[0] keys: ${stream.keys}")
+                        val dp = (stream["dataPort"] as? Long)?.toInt()
+                            ?: (stream["server_port"] as? Long)?.toInt()
+                        val cp = (stream["controlPort"] as? Long)?.toInt()
+                        if (dp != null && dp > 0) audioRemotePort = dp
+                        if (cp != null && cp > 0) controlRemotePort = cp
+                    }
+                }
+
+                if (dataPort != null && dataPort > 0) audioRemotePort = dataPort
+                if (ctrlPort != null && ctrlPort > 0) controlRemotePort = ctrlPort
+                if (evtPort != null && evtPort > 0) eventPort = evtPort
+                Log.d(TAG, "SETUP stream parsed: audio=$audioRemotePort ctrl=$controlRemotePort event=$eventPort")
+            } catch (e: Exception) {
+                Log.w(TAG, "SETUP stream plist parse failed: ${e.message}")
+            }
+        }
+
         audioSocket = DatagramSocket(0)
+
+        // When transient pairing skipped pair-verify, cipherKeys is null but the
+        // server expects encrypted audio because we sent shk. Use shk as the
+        // encryption key (the server uses the same shk to decrypt).
+        if (cipherKeys == null) {
+            cipherKeys = AirPlay2Crypto.PairKeysResult(shk, shk, 0L, 0L)
+            supportsEncryption = true
+            Log.d(TAG, "Using stream shared key for audio encryption (transient pairing)")
+        }
+
         return true
     }
 

--- a/app/src/main/java/com/aria/ariacast/airplay2/BinaryPlist.kt
+++ b/app/src/main/java/com/aria/ariacast/airplay2/BinaryPlist.kt
@@ -167,14 +167,14 @@ object BinaryPlist {
         "deviceID" to "00:00:00:00:00:00",
         "sessionUUID" to uuid.toString().uppercase(),
         "timingPort" to 0L,
-        "timingProtocol" to "NTP"
+        "timingProtocol" to "PTP"
     ))
 
     fun makeSessionPlist(uuid: UUID, deviceId: String, timingPort: Int): ByteArray = encode(mapOf(
         "deviceID" to deviceId,
         "sessionUUID" to uuid.toString().uppercase(),
         "timingPort" to timingPort.toLong(),
-        "timingProtocol" to "NTP"
+        "timingProtocol" to "PTP"
     ))
 
     fun decode(data: ByteArray): Map<String, Any?> {

--- a/app/src/main/java/com/aria/ariacast/raop/AudioResampler.kt
+++ b/app/src/main/java/com/aria/ariacast/raop/AudioResampler.kt
@@ -24,14 +24,27 @@ class AudioResampler(
         val totalTaps = tapsPerPhase * l
         filter = FloatArray(totalTaps)
 
-        val cutoff = 1.0f / m.toFloat()
+        val cutoff = 1.0f / maxOf(l, m).toFloat()
         val center = (totalTaps - 1) / 2.0f
 
         for (i in 0 until totalTaps) {
             val x = i.toFloat() - center
             val sinc = if (x == 0f) 1f else sin(PI.toFloat() * cutoff * x) / (PI.toFloat() * cutoff * x)
             val window = 0.54f - 0.46f * cos(2f * PI.toFloat() * i / (totalTaps - 1))
-            filter[i] = sinc * window * l
+            filter[i] = sinc * window
+        }
+
+        // Normalize each polyphase partition to unity gain
+        for (phase in 0 until l) {
+            var sum = 0f
+            for (i in 0 until tapsPerPhase) {
+                sum += filter[phase + i * l]
+            }
+            if (sum != 0f) {
+                for (i in 0 until tapsPerPhase) {
+                    filter[phase + i * l] /= sum
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The polyphase FIR resampler multiplied filter coefficients by `l` (the interpolation factor, 147 for 48000→44100). This is correct when the filter compensates for zero-stuffing, but this resampler computes output samples directly from input — no zero-stuffing step. The raw multiplication amplified samples by ~147×, causing severe clipping on any resampled audio.

Also fixes the cutoff frequency to use `max(l,m)` instead of just `m`, which is the correct Nyquist limit for the lower of the two sample rates.

Replaces the blanket multiplication with per-phase normalization: each polyphase partition's coefficients are divided by their sum, guaranteeing unity gain regardless of the filter shape.