### PR TITLE
feat: add Snapcast streaming protocol

### DIFF
--- a/app/src/main/java/com/aria/ariacast/AudioCastService.kt
+++ b/app/src/main/java/com/aria/ariacast/AudioCastService.kt
@@ -694,6 +694,7 @@ class AudioCastService : Service() {
                     "Google Cast" -> launch { startGoogleCastSession(dest) }
                     "AirPlay" -> launch { startAirPlaySession(dest) }
                     "AirPlay2" -> launch { startAirPlay2Session(dest) }
+                    "Snapcast" -> launch { startSnapcastSession(dest) }
                     else -> {
                         launch { startControlSession(dest) }
                         if (videoEnabled && destinations.size == 1) { 
@@ -1064,6 +1065,175 @@ class AudioCastService : Service() {
         } catch (e: Exception) {
             Log.e(TAG, "AirPlay 2 session failed for ${dest.name}: ${e.message}")
             _state.value = CastState.ERROR
+        }
+    }
+
+    private suspend fun startSnapcastSession(dest: CastDestination) = withContext(Dispatchers.IO) {
+        var streamId: String? = null
+        var rpcSocket: Socket? = null
+        var audioSocket: Socket? = null
+        var previousGroupStreams: Map<String, String>? = null // groupId → previous streamId
+        var rpcOut: java.io.OutputStream? = null
+        var rpcIn: java.io.BufferedReader? = null
+        var rpcSeq = 0
+
+        fun nextId() = ++rpcSeq
+
+        suspend fun rpcCall(method: String, params: JSONObject? = null): JSONObject {
+            val reqId = nextId()
+            val req = JSONObject().apply {
+                put("id", reqId)
+                put("jsonrpc", "2.0")
+                put("method", method)
+                if (params != null) put("params", params)
+            }.toString() + "\n"
+            rpcOut!!.write(req.toByteArray())
+            rpcOut!!.flush()
+            // Read lines until we get a response matching our request ID
+            // (snapserver sends async notifications on the same socket)
+            while (true) {
+                val line = rpcIn!!.readLine() ?: throw Exception("No response from snapserver")
+                val json = JSONObject(line)
+                // Match by request ID. Snapserver sends:
+                // - responses with "id" matching our request
+                // - error responses sometimes with "id": null
+                // - async notifications with "method" (no "id")
+                val respId = json.opt("id")
+                if (respId is Int && respId == reqId) {
+                    return json
+                }
+                // Accept null-id error responses as ours (they follow our request)
+                if (json.has("error") && (respId == null || respId == JSONObject.NULL)) {
+                    return json
+                }
+                Log.d(TAG, "Snapcast: skipped message: ${line.take(100)}")
+            }
+        }
+
+        try {
+            _state.value = CastState.CONNECTING
+
+            // 1. Connect to Snapcast JSON-RPC control API (discovered via _snapcast-ctrl._tcp)
+            rpcSocket = Socket()
+            rpcSocket.connect(java.net.InetSocketAddress(dest.host, dest.port), 5000)
+            rpcSocket.tcpNoDelay = true
+            rpcOut = rpcSocket.getOutputStream()
+            rpcIn = rpcSocket.getInputStream().bufferedReader()
+
+            // 2. Create a TCP source stream
+            // Request an explicit port (starting at 4953) so the URI includes it.
+            // Retry with incremented port and name suffix on collision.
+            val baseName = android.os.Build.MODEL ?: "Android"
+            var audioPort = 4953
+            var nameAttempt = 0
+            var portAttempt = 0
+
+            while (true) {
+                val name = if (nameAttempt == 0) baseName else "$baseName (${nameAttempt + 1})"
+                val port = audioPort + portAttempt
+
+                val resp = rpcCall("Stream.AddStream", JSONObject().apply {
+                    put("streamUri", "tcp://0.0.0.0:$port?name=$name&sampleformat=48000:16:2&mode=server")
+                })
+
+                if (!resp.has("error")) {
+                    streamId = resp.getJSONObject("result").optString("id", name)
+                    audioPort = port
+                    break
+                }
+
+                val errData = resp.optJSONObject("error")?.optString("data", "") ?: ""
+                if (errData.contains("already exists", ignoreCase = true)) {
+                    nameAttempt++
+                    Log.d(TAG, "Snapcast: name '$name' taken, trying next name")
+                } else if (errData.contains("Address already in use", ignoreCase = true) || errData.contains("bind", ignoreCase = true)) {
+                    portAttempt++
+                    Log.d(TAG, "Snapcast: port $port in use, trying next port")
+                } else {
+                    nameAttempt++
+                    portAttempt++
+                    Log.d(TAG, "Snapcast: '$name' on port $port failed ($errData), trying next")
+                }
+
+                if (nameAttempt >= 5 || portAttempt >= 5) {
+                    throw Exception("Snapcast: failed to create stream: $errData")
+                }
+            }
+
+            Log.d(TAG, "Snapcast stream '$streamId' on port $audioPort")
+
+            // Give snapserver time to bind the TCP source port
+            delay(500)
+
+            // 4. Connect to the TCP audio source port
+            audioSocket = Socket()
+            audioSocket.connect(java.net.InetSocketAddress(dest.host, audioPort), 5000)
+            audioSocket.tcpNoDelay = true
+            val audioOut = audioSocket.getOutputStream()
+
+            _state.value = CastState.CASTING
+            updateNotification()
+            Log.d(TAG, "Snapcast streaming to ${dest.host}:$audioPort (stream: $streamId)")
+
+            // 4. Save current group→stream assignments, then assign all groups to our stream
+            try {
+                val status = rpcCall("Server.GetStatus")
+                val groups = status.getJSONObject("result")
+                    .getJSONObject("server")
+                    .getJSONArray("groups")
+
+                val saved = mutableMapOf<String, String>()
+                for (i in 0 until groups.length()) {
+                    val group = groups.getJSONObject(i)
+                    val groupId = group.getString("id")
+                    saved[groupId] = group.getString("stream_id")
+
+                    rpcCall("Group.SetStream", JSONObject().apply {
+                        put("id", groupId)
+                        put("stream_id", streamId)
+                    })
+                }
+                previousGroupStreams = saved
+                Log.d(TAG, "Snapcast: assigned ${groups.length()} group(s), saved previous assignments")
+            } catch (e: Exception) {
+                Log.w(TAG, "Snapcast: failed to assign groups: ${e.message}")
+            }
+
+            // 5. Stream audio
+            try {
+                audioBufferFlow.collect { buffer ->
+                    audioOut.write(buffer)
+                }
+            } finally {
+                try { audioSocket.close() } catch (_: Exception) {}
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Snapcast session failed for ${dest.name}: ${e.message}")
+            _state.value = CastState.ERROR
+        } finally {
+            // 6. Restore previous group assignments and remove our stream
+            if (rpcSocket != null && !rpcSocket.isClosed) {
+                try {
+                    // Restore groups to their previous streams
+                    previousGroupStreams?.forEach { (groupId, prevStreamId) ->
+                        rpcCall("Group.SetStream", JSONObject().apply {
+                            put("id", groupId)
+                            put("stream_id", prevStreamId)
+                        })
+                    }
+                    if (previousGroupStreams != null) {
+                        Log.d(TAG, "Snapcast: restored previous group assignments")
+                    }
+
+                    // Remove our dynamic stream
+                    if (streamId != null) {
+                        rpcCall("Stream.RemoveStream", JSONObject().apply { put("id", streamId) })
+                        Log.d(TAG, "Snapcast stream '$streamId' removed")
+                    }
+                } catch (_: Exception) {}
+            }
+            try { rpcSocket?.close() } catch (_: Exception) {}
+            try { audioSocket?.close() } catch (_: Exception) {}
         }
     }
 

--- a/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
+++ b/app/src/main/java/com/aria/ariacast/DiscoveryManager.kt
@@ -180,8 +180,9 @@ class DiscoveryManager(private val context: Context) {
             attrString("ve")?.let { extraParts.add(ExtraFields.encode("ve", it)) }
         } else if (serviceInfo.serviceType.contains("_audiocast")) {
             platform = "AriaCast"
+        } else if (serviceInfo.serviceType.contains("_snapcast")) {
+            platform = "Snapcast"
         }
-
         // Ensure name is never empty
         if (name.trim().isEmpty()) {
             name = originalName
@@ -290,6 +291,9 @@ class DiscoveryManager(private val context: Context) {
         }
         if (prefs.getBoolean("google_cast_enabled", false)) {
             services.add("_googlecast._tcp")
+        }
+        if (prefs.getBoolean("snapcast_enabled", false)) {
+            services.add("_snapcast-ctrl._tcp")
         }
 
         discoveryJob = scope.launch {

--- a/app/src/main/java/com/aria/ariacast/ProtocolsActivity.kt
+++ b/app/src/main/java/com/aria/ariacast/ProtocolsActivity.kt
@@ -24,7 +24,7 @@ class ProtocolsActivity : AppCompatActivity() {
         val googleCastSwitch = findViewById<MaterialSwitch>(R.id.googleCastSwitch)
         val airPlaySwitch = findViewById<MaterialSwitch>(R.id.airPlaySwitch)
         val airPlay2Switch = findViewById<MaterialSwitch>(R.id.airPlay2Switch)
-
+        val snapcastSwitch = findViewById<MaterialSwitch>(R.id.snapcastSwitch)
         dlnaSwitch.isChecked = sharedPreferences.getBoolean(KEY_DLNA_ENABLED, false)
         dlnaSwitch.setOnCheckedChangeListener { _, isChecked ->
             sharedPreferences.edit().putBoolean(KEY_DLNA_ENABLED, isChecked).apply()
@@ -44,6 +44,11 @@ class ProtocolsActivity : AppCompatActivity() {
         airPlay2Switch.setOnCheckedChangeListener { _, isChecked ->
             sharedPreferences.edit().putBoolean(KEY_AIRPLAY2_ENABLED, isChecked).apply()
         }
+
+        snapcastSwitch.isChecked = sharedPreferences.getBoolean(KEY_SNAPCAST_ENABLED, false)
+        snapcastSwitch.setOnCheckedChangeListener { _, isChecked ->
+            sharedPreferences.edit().putBoolean(KEY_SNAPCAST_ENABLED, isChecked).apply()
+        }
     }
 
     companion object {
@@ -51,5 +56,6 @@ class ProtocolsActivity : AppCompatActivity() {
         const val KEY_GOOGLE_CAST_ENABLED = "google_cast_enabled"
         const val KEY_AIRPLAY_ENABLED = "airplay_enabled"
         const val KEY_AIRPLAY2_ENABLED = "airplay2_enabled"
+        const val KEY_SNAPCAST_ENABLED = "snapcast_enabled"
     }
 }

--- a/app/src/main/res/layout/activity_protocols.xml
+++ b/app/src/main/res/layout/activity_protocols.xml
@@ -203,7 +203,7 @@
                     android:id="@+id/airPlay2Switch"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:clickable="true" />
+                    android:clickable="false" />
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/activity_protocols.xml
+++ b/app/src/main/res/layout/activity_protocols.xml
@@ -117,6 +117,47 @@
                     android:layout_height="wrap_content" />
             </LinearLayout>
 
+
+            <!-- Snapcast -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="12dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@android:drawable/ic_media_play"
+                    app:tint="?attr/colorOnSurfaceVariant" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/snapcast_protocol"
+                        android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/snapcast_protocol_desc"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textColor="?android:attr/textColorSecondary" />
+                </LinearLayout>
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/snapcastSwitch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
             <!-- Google Cast -->
 
             <!-- AirPlay -->

--- a/app/src/main/res/layout/activity_protocols.xml
+++ b/app/src/main/res/layout/activity_protocols.xml
@@ -203,7 +203,7 @@
                     android:id="@+id/airPlay2Switch"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:clickable="false" />
+                    android:clickable="true" />
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
     <string name="airplay_protocol_desc">Stream to compatible AirPlay speakers</string>
     <string name="airplay2_protocol">AirPlay 2</string>
     <string name="airplay2_protocol_desc">Stream to Macs, Apple TVs and HomePods</string>
+    <string name="snapcast_protocol">Snapcast</string>
+    <string name="snapcast_protocol_desc">Stream to Snapcast multi-room audio servers</string>
 
     <!-- Plugins Activity -->
     <string name="plugin_folder_updated">Plugin folder updated</string>


### PR DESCRIPTION
Stream system audio to Snapcast multi-room servers. Fully dynamic.

## Discovery
- Discover snapservers via `_snapcast-ctrl._tcp` mDNS (the JSON-RPC control service)

## Session lifecycle
- Connect to the JSON-RPC API and create a TCP source stream via `Stream.AddStream`, starting at port 4953
- On collision, increment name and port independently: name conflicts bump the suffix ("Pixel 4a (2)"), port conflicts bump the port (4954)
- Save current group→stream assignments, assign all groups to the phone's stream, restore previous assignments on disconnect
- Remove our own stream via `Stream.RemoveStream` on disconnect

## Audio
- Stream raw PCM (48 kHz, 16-bit LE, stereo) over TCP

## UI
- Add Snapcast toggle in Protocol settings (positioned before AirPlay)

Tested against snapserver 0.35.0.